### PR TITLE
Documentation Addressing Integer Primary Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The following example demonstrates how to create an auto-incrementing ID column 
 ...     'users',
 ...     metadata,
 ...     sqlalchemy.Column(
+...         'id',
 ...         sqlalchemy.Integer,
 ...         user_id_seq,
 ...         server_default=user_id_seq.next_value(),

--- a/README.md
+++ b/README.md
@@ -30,3 +30,40 @@ frank = session.query(FakeModel).one()
 
 assert frank.name == "Frank"
 ```
+
+## Things to keep in mind
+Duckdb's SQL parser is based on the PostgreSQL parser, but not all features in PostgreSQL are supported in duckdb. Because the `duckdb_engine` dialect is derived from the `postgresql` dialect, `sqlalchemy` may try to use PostgreSQL-only features. Below are some caveats to look out for.
+
+### Auto-incrementing ID columns
+When defining an Integer column as a primary key, `sqlalchemy` uses the `SERIAL` datatype for PostgreSQL. Duckdb does not yet support this datatype because it's a non-standard PostgreSQL legacy type, so a workaround is to use the `sqlalchemy.Sequence()` object to auto-increment the key. For more information on sequences, you can find the [`sqlalchemy Sequence` documentation here](https://docs.sqlalchemy.org/en/14/core/defaults.html#associating-a-sequence-as-the-server-side-default).
+
+The following example demonstrates how to create an auto-incrementing ID column for a simple table:
+
+```python
+>>> import sqlalchemy
+>>> engine = sqlalchemy.create_engine('duckdb:////path/to/duck.db')
+>>> metadata = sqlalchemy.MetaData(engine)
+>>> user_id_seq = sqlalchemy.Sequence('user_id_seq')
+>>> users_table = sqlalchemy.Table(
+...     'users',
+...     metadata,
+...     sqlalchemy.Column(
+...         sqlalchemy.Integer,
+...         user_id_seq,
+...         server_default=user_id_seq.next_value(),
+...         primary_key=True,
+...     ),
+... )
+>>> metadata.create_all(bind=engine)
+```
+
+### Pandas `read_sql()` chunksize
+The `pandas.read_sql()` method can read tables from `duckdb_engine` into DataFrames, but the `sqlalchemy.engine.result.ResultProxy` trips up when `fetchmany()` is called. Therefore, for now `chunksize=None` (default) is necessary when reading duckdb tables into DataFrames. For example:
+
+```python
+>>> import pandas as pd
+>>> import sqlalchemy
+>>> engine = sqlalchemy.create_engine('duckdb:////path/to/duck.db')
+>>> df = pd.read_sql('users', engine)                ### Works as expected
+>>> df = pd.read_sql('users', engine, chunksize=25)  ### Throws an exception
+```


### PR DESCRIPTION
This PR is a continuation of the [discussion on the issue opened at `duckdb` about `SERIAL` datatypes](https://github.com/duckdb/duckdb/issues/1768). It might be helpful to include a snippet in the README to address the missing support for PostgreSQL-only datatypes like `SERIAL` and provide workarounds (like the `Sequence()` used in the existing example). I've written up some examples in this PR as suggestions.