### PR TITLE
FIX: update colspecs to handle numeric types

### DIFF
--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -1,11 +1,11 @@
 from typing import Any, Dict, List, Tuple, Type
 
 import duckdb
+from sqlalchemy import types as sqltypes
+from sqlalchemy import util
 from sqlalchemy.dialects.postgresql import dialect as postgres_dialect
 from sqlalchemy.dialects.postgresql.base import PGExecutionContext, PGInspector
 from sqlalchemy.engine import URL
-from sqlalchemy import util
-from sqlalchemy import types as sqltypes
 
 
 class DBAPI:

--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -4,6 +4,8 @@ import duckdb
 from sqlalchemy.dialects.postgresql import dialect as postgres_dialect
 from sqlalchemy.dialects.postgresql.base import PGExecutionContext, PGInspector
 from sqlalchemy.engine import URL
+from sqlalchemy import util
+from sqlalchemy import types as sqltypes
 
 
 class DBAPI:
@@ -85,6 +87,14 @@ class Dialect(postgres_dialect):
     server_version_info = (8, 0)
     inspector = DuckDBInspector
     # colspecs TODO: remap types to duckdb types
+    colspecs = util.update_copy(
+        postgres_dialect.colspecs,
+        {
+            # the psycopg2 driver registers a _PGNumeric with custom logic for
+            # postgres type_codes (such as 701 for float) that duckdb doesn't have
+            sqltypes.Numeric: sqltypes.Numeric,
+        },
+    )
 
     def connect(self, *args: Any, **kwargs: Any) -> ConnectionWrapper:
         return ConnectionWrapper(duckdb.connect(*args, **kwargs))

--- a/duckdb_engine/tests/test_pandas.py
+++ b/duckdb_engine/tests/test_pandas.py
@@ -11,7 +11,6 @@ from datetime import datetime
 from itertools import product
 from typing import Dict, List, Optional, Tuple, Union, cast
 
-import numpy as np
 import pandas as pd
 from pandas.testing import assert_frame_equal
 from pytest import mark, xfail
@@ -123,13 +122,16 @@ def run_query(query: str, chunksize: Optional[int]) -> None:
 
 def test_read_sql_duckdb_table(tmp_path):
     import duckdb
+
     db = str(tmp_path / "test_db.duckdb")
     con = duckdb.connect(database=db, read_only=False)
-    df = pd.DataFrame({'a': [1, 2, 3, 4], 'b': [.1, .2, .3, .4], 'c': ["a", "b", "c", "d"]})
-    con.register('df_view', df)
+    df = pd.DataFrame(
+        {"a": [1, 2, 3, 4], "b": [0.1, 0.2, 0.3, 0.4], "c": ["a", "b", "c", "d"]}
+    )
+    con.register("df_view", df)
     con.execute("CREATE TABLE test_data AS SELECT * FROM df_view;")
     engine = create_engine(f"duckdb:///{db}")
-    
+
     result = pd.read_sql("SELECT * FROM test_data", engine)
     assert_frame_equal(result, df)
     result = pd.read_sql("test_data", engine)

--- a/duckdb_engine/tests/test_pandas.py
+++ b/duckdb_engine/tests/test_pandas.py
@@ -131,6 +131,8 @@ def test_read_sql_duckdb_table(tmp_path: pathlib.Path) -> None:
     )
     con.register("df_view", df)
     con.execute("CREATE TABLE test_data AS SELECT * FROM df_view;")
+    con.close()
+
     engine = create_engine(f"duckdb:///{db}")
 
     result = pd.read_sql("SELECT * FROM test_data", engine)

--- a/duckdb_engine/tests/test_pandas.py
+++ b/duckdb_engine/tests/test_pandas.py
@@ -5,6 +5,7 @@
 Test pandas functionality.
 """
 
+import pathlib
 import random
 from collections import OrderedDict
 from datetime import datetime
@@ -120,7 +121,7 @@ def run_query(query: str, chunksize: Optional[int]) -> None:
         assert (sample_rowcount / chunksize) == len(chunks)
 
 
-def test_read_sql_duckdb_table(tmp_path):
+def test_read_sql_duckdb_table(tmp_path: pathlib.Path) -> None:
     import duckdb
 
     db = str(tmp_path / "test_db.duckdb")


### PR DESCRIPTION
Context: I am trying out this sqlalchemy dialect to connect DuckDB with ibis (https://github.com/ibis-project/ibis). So I might do some contributions for things I run into.

This is a first, as I ran into an error when doing a basic query:

```
            else:
                raise exc.InvalidRequestError(
>                   "Unknown PG numeric type: %d" % coltype
                )
E               TypeError: %d format: a number is required, not str

../../../miniconda3/envs/test-duckdb/lib/python3.9/site-packages/sqlalchemy/dialects/postgresql/psycopg2.py:525: TypeError
```

This was from the psycopg2 driver which adds a custom `_PGNumeric` type (https://github.com/sqlalchemy/sqlalchemy/blob/70a33dd32f2609f2de6421c3b28ef4cc4496fdae/lib/sqlalchemy/dialects/postgresql/psycopg2.py#L500). But that expects that the `col_type` in the cursor's description is a number, while duckdb just uses "NUMBER" (https://github.com/duckdb/duckdb/blob/a776543eec63d16134af7583122252537b89677f/tools/pythonpkg/src/pyresult.cpp#L326)