### PR TITLE
fix: Fix rowcount for duckdb version > 0.3.0

### DIFF
--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -64,7 +64,7 @@ class ConnectionWrapper:
 
     @property
     def rowcount(self) -> int:
-        return self.c.rowcount or -1
+        return -1
 
     def executemany(
         self, statement: str, parameters: List[Dict] = None, context: Any = None


### PR DESCRIPTION
This was "broken" by https://github.com/duckdb/duckdb/pull/2389 (the rowcount attribute never actually existed)