### PR TITLE
Support SQLAlchemy < 1.4 without a deprecation warning on 1.4+

### DIFF
--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -153,7 +153,13 @@ class Dialect(postgres_dialect):
         return DBAPI
 
     def create_connect_args(self, u: URL) -> Tuple[Tuple, Dict]:
-        return (), {"database": u.__to_string__(hide_password=False).split("///")[1]}
+        if hasattr(u, "render_as_string"):
+            # Compatible with SQLAlchemy >= 1.4
+            string_representation = u.render_as_string(hide_password=False)
+        else:
+            # Compatible with SQLAlchemy < 1.4
+            string_representation = u.__to_string__(hide_password=False)
+        return (), {"database": string_representation.split("///")[1]}
 
     def _get_server_version_info(
         self, connection: ConnectionWrapper


### PR DESCRIPTION
Thanks for a great package! Here's a small tweak:
* [A recent PR](https://github.com/Mause/duckdb_engine/pull/180) introduced backward-compatibility for SQLAlchemy < 1.4
* The replaced method is [being deprecated](https://github.com/zzzeek/sqlalchemy/blob/fc5c54fcd4d868c2a4c7ac19668d72f506fe821e/lib/sqlalchemy/engine/url.py#L504) and is causing deprecation warnings on newer versions of SQLAlchemy
* The [docs suggest an easy way to keep backward-compatibility](https://docs.sqlalchemy.org/en/14/changelog/migration_14.html#the-url-object-is-now-immutable) without receiving deprecation warnings in future versions
* This PR implements that suggestion
* Note: I wasn't sure how to run tests---if there's anything I should do beyond what I've already done, let me know. Perhaps GH Actions will run tests in your repo?