### PR TITLE
feat: set duckdb as dialect name

### DIFF
--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -7,8 +7,6 @@ from sqlalchemy.dialects.postgresql import dialect as postgres_dialect
 from sqlalchemy.dialects.postgresql.base import PGExecutionContext, PGInspector
 from sqlalchemy.engine.url import URL
 
-name = "duckdb"
-
 
 class DBAPI:
     paramstyle = "qmark"
@@ -98,6 +96,7 @@ class ConnectionWrapper:
 
 
 class Dialect(postgres_dialect):
+    name = "duckdb"
     _has_events = False
     identifier_preparer = None
     inspector = DuckDBInspector


### PR DESCRIPTION
This PR sets the name in the dialect class to "duckdb". This will let SQLAlchemy identify the dialect as "duckdb" in warnings and errors (and maybe other things?).

```
from sqlalchemy import create_engine

engine = create_engine("duckdb:///:memory:")

# before was "postgresql", now is "duckdb"
engine.dialect.name

# in this case sqlalchemy thinks it's using duckdb with the psycopg2 driver (default for postgres)
engine.dialect.driver
```