### PR TITLE
fix: explicitly disable statement_cache for sqlalchemy 1.4

### DIFF
--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -99,6 +99,7 @@ class Dialect(postgres_dialect):
     name = "duckdb"
     _has_events = False
     identifier_preparer = None
+    supports_statement_cache = False
     inspector = DuckDBInspector
     # colspecs TODO: remap types to duckdb types
     colspecs = util.update_copy(


### PR DESCRIPTION
SQLAlchemy 1.4 introduced the statement cache -- it might be good to
enable this once it is tested, but for the moment, it raises a warning
on every first execution which is quite noisy.

```
/home/gil/github.com/ibis-project/ibis/ibis/backends/base/sql/alchemy/__init__.py:362:
SAWarning: Dialect postgresql:psycopg2 will not make use of SQL
compilation caching as it does not set the 'supports_statement_cache'
attribute to ``True``.  This can have significant performance
implications including some performance degradations in comparison to
prior SQLAlchemy versions.  Dialect maintainers should seek to set this
attribute to True after appropriate development and testing for
SQLAlchemy 1.4 caching support.   Alternatively, this attribute may be
set to False which will disable this warning. (Background on this error
at: https://sqlalche.me/e/14/cprf) return sa.Table(name, self.meta,
schema=schema, autoload=autoload)
```

For now, explicitly setting support to `False` stops the noise.