### PR TITLE
feat: override driver name

### DIFF
--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -97,6 +97,7 @@ class ConnectionWrapper:
 
 class Dialect(postgres_dialect):
     name = "duckdb"
+    driver = "duckdb_engine"
     _has_events = False
     identifier_preparer = None
     supports_statement_cache = False


### PR DESCRIPTION
otherwise this is populated with psycopg2
