### PR TITLE
chore: delete isort.cfg

### DIFF
--- a/duckdb_engine/.isort.cfg
+++ b/duckdb_engine/.isort.cfg
@@ -1,2 +1,0 @@
-[isort]
-profile=black


### PR DESCRIPTION
Has long since been moved to pyproject.toml