### PR TITLE
fix: strip comments from generated sql

### DIFF
--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Type
 
 import duckdb
@@ -108,7 +109,12 @@ class DuckDBEngineWarning(Warning):
     pass
 
 
+class DuckDBEngineCommentWarning(DuckDBEngineWarning):
+    pass
+
+
 def remove_comments(ddl: "ExecutableDDLElement") -> None:
+    # TODO: swap these attribute checks for type checks
     if hasattr(ddl, "element"):
         remove_comments(ddl.element)
     elif hasattr(ddl, "elements"):
@@ -118,8 +124,12 @@ def remove_comments(ddl: "ExecutableDDLElement") -> None:
         for col in ddl.columns:
             remove_comments(col)
 
-    if hasattr(ddl, "comment"):
+    if hasattr(ddl, "comment") and ddl.comment:
         ddl.comment = None
+        warnings.warn(
+            "Stripping a comment, as duckdb does not support them",
+            category=DuckDBEngineCommentWarning,
+        )
 
 
 class Dialect(postgres_dialect):

--- a/duckdb_engine/tests/conftest.py
+++ b/duckdb_engine/tests/conftest.py
@@ -1,12 +1,15 @@
+from functools import wraps
 from typing import Any, Callable, TypeVar
 
 import duckdb
 from packaging.specifiers import SpecifierSet
-from pytest import fixture, mark
+from pytest import fixture, mark, raises
 from sqlalchemy import create_engine
 from sqlalchemy.dialects import registry
 from sqlalchemy.engine import Engine
-from typing_extensions import Protocol
+from typing_extensions import ParamSpec, Protocol
+
+P = ParamSpec("P")
 
 FuncT = TypeVar("FuncT", bound=Callable[..., Any])
 
@@ -38,6 +41,18 @@ def library_version(
 
     installed = library.__version__
     has_version = SpecifierSet(specifiers).contains(installed, prereleases=True)
+
+    return decorator
+
+
+def raises_msg(msg: str) -> Callable[[Callable[P, None]], Callable[P, None]]:
+    def decorator(func: Callable[P, None]) -> Callable[P, None]:
+        @wraps(func)
+        def wrapped_test(*args: P.args, **kwargs: P.kwargs) -> None:
+            with raises(RuntimeError, match=msg):
+                func(*args, **kwargs)
+
+        return wrapped_test
 
     return decorator
 

--- a/duckdb_engine/tests/test_basic.py
+++ b/duckdb_engine/tests/test_basic.py
@@ -234,3 +234,10 @@ def test_binary(session: Session) -> None:
 
     b: TableWithBinary = session.scalar(select(TableWithBinary))  # type: ignore
     assert b.text == "Hello World!"
+
+
+@mark.xfail(reason="comments not yet supported by duckdb", raises=RuntimeError)
+def test_comment_support() -> None:
+    import duckdb
+
+    duckdb.default_connection.execute('comment on sqlite_master is "hello world";')

--- a/duckdb_engine/tests/test_basic.py
+++ b/duckdb_engine/tests/test_basic.py
@@ -25,6 +25,8 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import RelationshipProperty, Session, relationship, sessionmaker
 
+from .conftest import raises_msg
+
 
 @fixture
 def engine() -> Engine:
@@ -236,8 +238,9 @@ def test_binary(session: Session) -> None:
     assert b.text == "Hello World!"
 
 
-@mark.xfail(reason="comments not yet supported by duckdb", raises=RuntimeError)
+@raises_msg("syntax error")
 def test_comment_support() -> None:
+    "comments not yet supported by duckdb"
     import duckdb
 
     duckdb.default_connection.execute('comment on sqlite_master is "hello world";')


### PR DESCRIPTION
- feat: strip comments from generated sql
- test: add canary test for comment support
- feat: warn when we find comments in the ddl
- test: add and use raises_msg decorator
