### PR TITLE
fix: correct get_view_names for older sqlalchemy

### DIFF
--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -203,8 +203,8 @@ class Dialect(PGDialect_psycopg2):
     def get_view_names(
         self,
         connection: Any,
-        schema: Optional[Any] = ...,
-        include: Any = ...,
+        schema: Optional[Any] = None,
+        include: Any = None,
         **kw: Any,
     ) -> Any:
         s = f"SELECT table_name FROM information_schema.tables WHERE table_type='VIEW' and table_schema=?"

--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -207,7 +207,7 @@ class Dialect(PGDialect_psycopg2):
         include: Any = ...,
         **kw: Any,
     ) -> Any:
-        s = "SELECT name FROM sqlite_master WHERE type='view' ORDER BY name"
-        rs = connection.exec_driver_sql(s)
+        s = f"SELECT table_name FROM information_schema.tables WHERE table_type='VIEW' and table_schema=?"
+        rs = connection.execute( s,schema if schema is not None else 'main' )
 
         return [row[0] for row in rs]

--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -208,6 +208,6 @@ class Dialect(PGDialect_psycopg2):
         **kw: Any,
     ) -> Any:
         s = f"SELECT table_name FROM information_schema.tables WHERE table_type='VIEW' and table_schema=?"
-        rs = connection.execute( s,schema if schema is not None else 'main' )
+        rs = connection.execute(s, schema if schema is not None else "main")
 
         return [row[0] for row in rs]

--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type
 
 import duckdb
+import sqlalchemy
 from sqlalchemy import pool
 from sqlalchemy import types as sqltypes
 from sqlalchemy import util
@@ -8,7 +9,6 @@ from sqlalchemy.dialects.postgresql.base import PGInspector, PGTypeCompiler
 from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
 from sqlalchemy.engine.url import URL
 from sqlalchemy.ext.compiler import compiles
-import sqlalchemy
 
 from . import datatypes
 from .config import apply_config, get_core_config
@@ -209,9 +209,9 @@ class Dialect(PGDialect_psycopg2):
         **kw: Any,
     ) -> Any:
         schema = schema if schema is not None else "main"
-        if sqlalchemy.__version__<'1.4':
+        if sqlalchemy.__version__ < "1.4":
             s = f"SELECT table_name FROM information_schema.tables WHERE table_type='VIEW' and table_schema=? "
-            rs = connection.execute(s , schema)
+            rs = connection.execute(s, schema)
         else:
             s = f"SELECT table_name FROM information_schema.tables WHERE table_type='VIEW' and table_schema='%s' "
             schema = schema if schema is not None else "main"

--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -207,7 +207,7 @@ class Dialect(PGDialect_psycopg2):
         include: Any = None,
         **kw: Any,
     ) -> Any:
-        s = f"SELECT table_name FROM information_schema.tables WHERE table_type='VIEW' and table_schema=?"
-        rs = connection.execute(s, schema if schema is not None else "main")
+        s = f"SELECT table_name FROM information_schema.tables WHERE table_type='VIEW' and table_schema=%s "
+        rs = connection.exec_driver_sql(s, % schema if schema is not None else "main")
 
         return [row[0] for row in rs]

--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -208,6 +208,7 @@ class Dialect(PGDialect_psycopg2):
         **kw: Any,
     ) -> Any:
         s = f"SELECT table_name FROM information_schema.tables WHERE table_type='VIEW' and table_schema=%s "
-        rs = connection.exec_driver_sql(s, % schema if schema is not None else "main")
+        schema = schema if schema is not None else "main"
+        rs = connection.exec_driver_sql(s % schema)
 
         return [row[0] for row in rs]

--- a/duckdb_engine/tests/test_basic.py
+++ b/duckdb_engine/tests/test_basic.py
@@ -146,10 +146,16 @@ def test_get_views(engine: Engine) -> None:
     assert views == []
 
     engine.execute(text("create view test as select 1"))
+    engine.execute(
+        text("create schema scheme; create view scheme.schema_test as select 1")
+    )
 
     con = engine.connect()
     views = engine.dialect.get_view_names(con)
     assert views == ["test"]
+
+    views = engine.dialect.get_view_names(con, schema="scheme")
+    assert views == ["schema_test"]
 
 
 @mark.skipif(os.uname().machine == "aarch64", reason="not supported on aarch64")


### PR DESCRIPTION
- fix bug
```
AttributeError: 'Connection' object has no attribute 'exec_driver_sql'
```
- add schema support.

BEGIN_COMMIT_OVERRIDE
fix: add schema support to get_view_names
END_COMMIT_OVERRIDE