### PR TITLE
fix: correct get_view_names for older sqlalchemy 

### DIFF
--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -203,8 +203,8 @@ class Dialect(PGDialect_psycopg2):
     def get_view_names(
         self,
         connection: Any,
-        schema: Optional[Any] = ...,
-        include: Any = ...,
+        schema: Optional[Any] = None,
+        include: Any = None,
         **kw: Any,
     ) -> Any:
         s = f"SELECT table_name FROM information_schema.tables WHERE table_type='VIEW' and table_schema=?"

--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -207,7 +207,7 @@ class Dialect(PGDialect_psycopg2):
         include: Any = ...,
         **kw: Any,
     ) -> Any:
-        s = "SELECT name FROM sqlite_master WHERE type='view' ORDER BY name"
-        rs = connection.exec_driver_sql(s)
+        s = f"SELECT table_name FROM information_schema.tables WHERE table_type='VIEW' and table_schema=?"
+        rs = connection.execute( s,schema if schema is not None else 'main' )
 
         return [row[0] for row in rs]

--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -208,6 +208,6 @@ class Dialect(PGDialect_psycopg2):
         **kw: Any,
     ) -> Any:
         s = f"SELECT table_name FROM information_schema.tables WHERE table_type='VIEW' and table_schema=?"
-        rs = connection.execute( s,schema if schema is not None else 'main' )
+        rs = connection.execute(s, schema if schema is not None else "main")
 
         return [row[0] for row in rs]

--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -207,7 +207,7 @@ class Dialect(PGDialect_psycopg2):
         include: Any = None,
         **kw: Any,
     ) -> Any:
-        s = f"SELECT table_name FROM information_schema.tables WHERE table_type='VIEW' and table_schema=?"
+        s = "SELECT table_name FROM information_schema.tables WHERE table_type='VIEW' and table_schema=?"
         rs = connection.execute(s, schema if schema is not None else "main")
 
         return [row[0] for row in rs]

--- a/duckdb_engine/tests/test_basic.py
+++ b/duckdb_engine/tests/test_basic.py
@@ -146,10 +146,16 @@ def test_get_views(engine: Engine) -> None:
     assert views == []
 
     engine.execute(text("create view test as select 1"))
+    engine.execute(
+        text("create schema scheme; create view scheme.schema_test as select 1")
+    )
 
     con = engine.connect()
     views = engine.dialect.get_view_names(con)
     assert views == ["test"]
+
+    views = engine.dialect.get_view_names(con, schema="scheme")
+    assert views == ["schema_test"]
 
 
 @mark.skipif(os.uname().machine == "aarch64", reason="not supported on aarch64")


### PR DESCRIPTION
Extracted from #393

BEGIN_COMMIT_OVERRIDE
fix: add schema support to get_view_names
END_COMMIT_OVERRIDE