### PR TITLE
refactor: type cleanliness for SQLA2 support

### DIFF
--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -61,7 +61,7 @@ class ConnectionWrapper:
         return self
 
     def fetchmany(self, size: Optional[int] = None) -> List:
-        if hasattr(self.c, "fetchmany"):
+        if hasattr(self.__c, "fetchmany"):
             # fetchmany was only added in 0.5.0
             if size is None:
                 return self.__c.fetchmany()

--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -2,7 +2,7 @@ import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, cast
 
 import duckdb
-from sqlalchemy import pool
+from sqlalchemy import pool, text
 from sqlalchemy import types as sqltypes
 from sqlalchemy import util
 from sqlalchemy.dialects.postgresql.base import PGInspector
@@ -224,7 +224,7 @@ class Dialect(PGDialect_psycopg2):
         **kw: Any,
     ) -> Any:
         s = "SELECT table_name FROM information_schema.tables WHERE table_type='VIEW' and table_schema=?"
-        rs = connection.execute(s, schema if schema is not None else "main")
+        rs = connection.execute(text(s), schema if schema is not None else "main")
 
         return [row[0] for row in rs]
 

--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -223,8 +223,10 @@ class Dialect(PGDialect_psycopg2):
         include: Optional[Any] = None,
         **kw: Any,
     ) -> Any:
-        s = "SELECT table_name FROM information_schema.tables WHERE table_type='VIEW' and table_schema=?"
-        rs = connection.execute(text(s), schema if schema is not None else "main")
+        s = "SELECT table_name FROM information_schema.tables WHERE table_type='VIEW' and table_schema=:schema_name"
+        rs = connection.execute(
+            text(s), {"schema_name": schema if schema is not None else "main"}
+        )
 
         return [row[0] for row in rs]
 

--- a/duckdb_engine/tests/test_basic.py
+++ b/duckdb_engine/tests/test_basic.py
@@ -183,7 +183,7 @@ def test_preload_extension() -> None:
     # check that we get an error indicating that the extension was loaded
     with engine.connect() as conn, raises(Exception, match="HTTP HEAD"):
         conn.execute(
-            "SELECT * FROM read_parquet('https://domain/path/to/file.parquet');"
+            text("SELECT * FROM read_parquet('https://domain/path/to/file.parquet');")
         )
 
 

--- a/duckdb_engine/tests/test_integration.py
+++ b/duckdb_engine/tests/test_integration.py
@@ -4,6 +4,7 @@ from sqlalchemy.engine import Engine
 
 
 def test_integration(engine: Engine) -> None:
-    engine.execute(text("register"), ("test_df", pd.DataFrame([{"a": 1}])))
+    with engine.connect() as conn:
+        conn.execute(text("register"), ("test_df", pd.DataFrame([{"a": 1}])))
 
-    engine.execute(text("select * from test_df"))
+        conn.execute(text("select * from test_df"))

--- a/duckdb_engine/tests/test_integration.py
+++ b/duckdb_engine/tests/test_integration.py
@@ -1,8 +1,9 @@
 import pandas as pd
+from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
 
 def test_integration(engine: Engine) -> None:
-    engine.execute("register", ("test_df", pd.DataFrame([{"a": 1}])))
+    engine.execute(text("register"), ("test_df", pd.DataFrame([{"a": 1}])))
 
-    engine.execute("select * from test_df")
+    engine.execute(text("select * from test_df"))

--- a/duckdb_engine/tests/test_integration.py
+++ b/duckdb_engine/tests/test_integration.py
@@ -5,6 +5,10 @@ from sqlalchemy.engine import Engine
 
 def test_integration(engine: Engine) -> None:
     with engine.connect() as conn:
-        conn.execute(text("register"), ("test_df", pd.DataFrame([{"a": 1}])))
+        execute = (
+            conn.exec_driver_sql if hasattr(conn, "exec_driver_sql") else conn.execute
+        )
+        params = ("test_df", pd.DataFrame([{"a": 1}]))
+        execute("register", params)  # type: ignore[operator]
 
         conn.execute(text("select * from test_df"))


### PR DESCRIPTION
Mostly cleaning up depreciation warnings, that are becoming hard errors in SQLA2