### PR TITLE
fix: Update __init__.py

### DIFF
--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -178,6 +178,7 @@ class Dialect(PGDialect_psycopg2):
         conn = duckdb.connect(*cargs, **cparams)
 
         for extension in preload_extensions:
+            conn.execute(f"INSTALL {extension}")
             conn.execute(f"LOAD {extension}")
 
         apply_config(self, conn, ext)


### PR DESCRIPTION
conn.execute(f"INSTALL {extension}") before conn.execute(f"LOAD {extension}") otherwise the Superset dialog and advanced database properties will fail.