### PR TITLE
fix: qualify catalog names with schema names in get_schema_names

### DIFF
--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -271,8 +271,8 @@ class Dialect(PGDialect_psycopg2):
         s = """
             SELECT database_name, schema_name AS npspname
             FROM duckdb_schemas()
-            WHERE schema_name NOT LIKE 'pg\\_%' ESCAPE '\'
-            ORDER BY npspname
+            WHERE schema_name NOT LIKE 'pg\\_%' ESCAPE '\\'
+            ORDER BY database_name, npspname
             """
         rs = connection.execute(text(s))
 

--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -22,6 +22,7 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.dialects.postgresql.base import PGDialect, PGInspector, PGTypeCompiler
 from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
 from sqlalchemy.engine.default import DefaultDialect
+from sqlalchemy.engine.reflection import cache
 from sqlalchemy.engine.url import URL
 from sqlalchemy.ext.compiler import compiles
 
@@ -259,7 +260,8 @@ class Dialect(PGDialect_psycopg2):
 
         return [row[0] for row in rs]
 
-    def get_schema_names(self, connection, **kw) -> Any:
+    @cache  # type: ignore[call-arg]
+    def get_schema_names(self, connection: "Connection", **kw: "Any"):  # type: ignore[no-untyped-def]
         """
         Return unquoted database_name.schema_name unless either contains spaces or double quotes.
         In that case, escape double quotes and then wrap in double quotes.
@@ -267,23 +269,15 @@ class Dialect(PGDialect_psycopg2):
         (see https://docs.sqlalchemy.org/en/20/dialects/mssql.html#multipart-schema-names)
         """
         s = """
-            SELECT
-                CASE
-                    WHEN contains(database_name, ' ') OR contains(database_name, '"') THEN '"' || replace(database_name, '"', '""') || '"'
-                    ELSE database_name
-                END
-                || '.' ||
-                CASE
-                    WHEN contains(schema_name, ' ') OR contains(schema_name, '"') THEN '"' || replace(schema_name, '"', '""') || '"'
-                    ELSE schema_name
-                END AS npspname
+            SELECT database_name, schema_name AS npspname
             FROM duckdb_schemas()
             WHERE schema_name NOT LIKE 'pg\\_%' ESCAPE '\'
             ORDER BY npspname
             """
         rs = connection.execute(text(s))
 
-        return [row[0] for row in rs]
+        qs = self.identifier_preparer.quote_schema
+        return [f"{qs(db)}.{qs(schema)}" for (db, schema) in rs]
 
     def get_indexes(
         self,

--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -261,29 +261,27 @@ class Dialect(PGDialect_psycopg2):
 
     def get_schema_names(self, connection, **kw) -> Any:
         """
-        Return unquoted database_name.schema_name unless either contains spaces or double quotes. 
+        Return unquoted database_name.schema_name unless either contains spaces or double quotes.
         In that case, escape double quotes and then wrap in double quotes.
         SQLAlchemy definition of a schema includes database name for databases like SQL Server (Ex: databasename.dbo)
         (see https://docs.sqlalchemy.org/en/20/dialects/mssql.html#multipart-schema-names)
         """
         s = """
-            SELECT 
-                CASE 
-                    WHEN contains(database_name, ' ') OR contains(database_name, '"') THEN '"' || replace(database_name, '"', '""') || '"' 
-                    ELSE database_name 
-                END 
-                || '.' || 
-                CASE 
-                    WHEN contains(schema_name, ' ') OR contains(schema_name, '"') THEN '"' || replace(schema_name, '"', '""') || '"' 
-                    ELSE schema_name 
-                END AS npspname 
+            SELECT
+                CASE
+                    WHEN contains(database_name, ' ') OR contains(database_name, '"') THEN '"' || replace(database_name, '"', '""') || '"'
+                    ELSE database_name
+                END
+                || '.' ||
+                CASE
+                    WHEN contains(schema_name, ' ') OR contains(schema_name, '"') THEN '"' || replace(schema_name, '"', '""') || '"'
+                    ELSE schema_name
+                END AS npspname
             FROM duckdb_schemas()
-            WHERE schema_name NOT LIKE 'pg\_%' ESCAPE '\' 
+            WHERE schema_name NOT LIKE 'pg\\_%' ESCAPE '\'
             ORDER BY npspname
             """
-        rs = connection.execute(
-            text(s)
-        )
+        rs = connection.execute(text(s))
 
         return [row[0] for row in rs]
 

--- a/duckdb_engine/tests/snapshots/snap_test_basic.py
+++ b/duckdb_engine/tests/snapshots/snap_test_basic.py
@@ -1,6 +1,9 @@
+# -*- coding: utf-8 -*-
 # snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
 
 from snapshottest import GenericRepr, Snapshot
+
 
 snapshots = Snapshot()
 
@@ -13,4 +16,18 @@ snapshots["test_get_columns 1"] = [
         "nullable": True,
         "type": GenericRepr("INTEGER()"),
     }
+]
+
+snapshots["test_get_schema_names 1"] = [
+    'memory."hello world"',
+    "memory.information_schema",
+    "memory.main",
+    '"my db"."cursed "" schema"',
+    '"my db"."hello world"',
+    '"my db".information_schema',
+    '"my db".main',
+    "system.information_schema",
+    "system.main",
+    "temp.information_schema",
+    "temp.main",
 ]

--- a/duckdb_engine/tests/snapshots/snap_test_basic.py
+++ b/duckdb_engine/tests/snapshots/snap_test_basic.py
@@ -1,9 +1,6 @@
-# -*- coding: utf-8 -*-
 # snapshottest: v1 - https://goo.gl/zC4yUc
-from __future__ import unicode_literals
 
 from snapshottest import GenericRepr, Snapshot
-
 
 snapshots = Snapshot()
 

--- a/duckdb_engine/tests/test_basic.py
+++ b/duckdb_engine/tests/test_basic.py
@@ -165,6 +165,27 @@ def test_get_tables(inspector: Inspector) -> None:
     assert inspector.get_view_names() == []
 
 
+def test_get_schema_names(inspector: Inspector, engine: Engine) -> None:
+    with engine.connect() as conn:
+        conn.exec_driver_sql('CREATE SCHEMA "hello world"')
+        conn.exec_driver_sql("ATTACH ':memory:' AS \"my db\"")
+    assert inspector.get_schema_names() == [
+        'memory."hello world"',
+        "memory.information_schema",
+        "system.information_schema",
+        "temp.information_schema",
+        '"my db".information_schema',
+        "memory.main",
+        "system.main",
+        "temp.main",
+        '"my db".main',
+        "memory.pg_catalog",
+        "system.pg_catalog",
+        "temp.pg_catalog",
+        '"my db".pg_catalog',
+    ]
+
+
 def test_get_views(engine: Engine) -> None:
     con = engine.connect()
     views = engine.dialect.get_view_names(con)

--- a/duckdb_engine/tests/test_basic.py
+++ b/duckdb_engine/tests/test_basic.py
@@ -5,13 +5,13 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Generic, Optional, TypeVar, cast
 
-from snapshottest.module import SnapshotTest
 import duckdb
 import sqlalchemy
 from hypothesis import assume, given, settings
 from hypothesis.strategies import text as text_strat
 from packaging.version import Version
 from pytest import LogCaptureFixture, fixture, importorskip, mark, raises
+from snapshottest.module import SnapshotTest
 from sqlalchemy import (
     Column,
     DateTime,

--- a/duckdb_engine/tests/test_basic.py
+++ b/duckdb_engine/tests/test_basic.py
@@ -167,22 +167,25 @@ def test_get_tables(inspector: Inspector) -> None:
 
 def test_get_schema_names(inspector: Inspector, engine: Engine) -> None:
     with engine.connect() as conn:
-        conn.exec_driver_sql('CREATE SCHEMA "hello world"')
-        conn.exec_driver_sql("ATTACH ':memory:' AS \"my db\"")
+        # Using multi-line strings because of all the single and double quotes flying around...
+        conn.exec_driver_sql("""CREATE SCHEMA "hello world" """)
+        conn.exec_driver_sql("""ATTACH ':memory:' AS "my db" """)
+        conn.exec_driver_sql("""CREATE SCHEMA "my db"."hello world" """)
+        conn.exec_driver_sql("""CREATE SCHEMA "my db"."cursed "" schema" """)
+
+    # Deliberately excluding pg_catalog schema (to align with Postgres)
     assert inspector.get_schema_names() == [
         'memory."hello world"',
         "memory.information_schema",
-        "system.information_schema",
-        "temp.information_schema",
-        '"my db".information_schema',
         "memory.main",
-        "system.main",
-        "temp.main",
+        '"my db"."cursed "" schema"',
+        '"my db"."hello world"',
+        '"my db".information_schema',
         '"my db".main',
-        "memory.pg_catalog",
-        "system.pg_catalog",
-        "temp.pg_catalog",
-        '"my db".pg_catalog',
+        "system.information_schema",
+        "system.main",
+        "temp.information_schema",
+        "temp.main",
     ]
 
 


### PR DESCRIPTION
Due to having multiple databases in DuckDB, the Postgres dialect of get_schema_names has duplicates (Ex: one copy of "main" for every database, including temp and system).

This is a draft because it has no tests! I just wanted to post here to get some quick feedback and I'll definitely add some tests in the next day or two. If you have specific advice or requests for tests, definitely let me know!

I tried to only wrap things in double quotes when absolutely necessary (if there are spaces or quotes within the database or schema name). Let me know if you think this will work!

One other factor is that we could go back and edit DuckDB core's pg_namespaces catalog to include the database name as the namespace. Then we could query pg_namespaces instead of duckdb_schemas. I'm not sure if that is something we want to do though!