### PR TITLE
updated readme to handle sqlalchemy deprecation for declarative_base : MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Once you've installed this package, you should be able to just use it, as SQLAlc
 
 ```python
 from sqlalchemy import Column, Integer, Sequence, String, create_engine
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm.session import Session
 
 Base = declarative_base()


### PR DESCRIPTION
…: MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)