### PR TITLE
fix: support getting table properties using schema with db name prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ __pycache__/
 htmlcov/
 .coverage
 coverage.xml
+.DS_Store
+.hypothesis/*
+.idea
+.vscode
+results.xml
+venv

--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -478,8 +478,9 @@ class Dialect(PGDialect_psycopg2):
         schema: "Optional[str]" = None,
         **kw: "Any",
     ):
+        # Support schema name with db name prefix
         _, schema = self.identifier_preparer._separate(schema)
-        return super().get_columns(connection, table_name, schema=None, **kw)
+        return super().get_columns(connection, table_name, schema=schema, **kw)
 
     @cache  # type: ignore[call-arg]
     def get_foreign_keys(  # type: ignore[no-untyped-def]
@@ -490,11 +491,12 @@ class Dialect(PGDialect_psycopg2):
         postgresql_ignore_search_path: bool = False,
         **kw: "Any",
     ):
+        # Support schema name with db name prefix
         _, schema = self.identifier_preparer._separate(schema)
         return super().get_foreign_keys(
             connection,
             table_name,
-            schema=None,
+            schema=schema,
             postgresql_ignore_search_path=False,
             **kw,
         )
@@ -507,6 +509,7 @@ class Dialect(PGDialect_psycopg2):
         schema: "Optional[str]" = None,
         **kw: "Any",
     ):
+        # Support schema name with db name prefix
         _, schema = self.identifier_preparer._separate(schema)
         return super().get_check_constraints(connection, table_name, schema, **kw)
 
@@ -518,6 +521,7 @@ class Dialect(PGDialect_psycopg2):
         schema: "Optional[str]" = None,
         **kw: "Any",
     ):
+        # Support schema name with db name prefix
         _, schema = self.identifier_preparer._separate(schema)
         return super().get_unique_constraints(connection, table_name, schema, **kw)
 
@@ -554,6 +558,7 @@ class Dialect(PGDialect_psycopg2):
         SOFTWARE.
         """
 
+        # Support schema name with db name prefix
         _, schema = self.identifier_preparer._separate(schema)
         has_filter_names, params = self._prepare_filter_names(filter_names)  # type: ignore[attr-defined]
         query = self._columns_query(schema, has_filter_names, scope, kind)  # type: ignore[attr-defined]

--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -182,7 +182,7 @@ def index_warning() -> None:
 
 
 class DuckDBIdentifierPreparer(PGIdentifierPreparer):
-    def _separate(self, name) -> Tuple[Optional[str], str]:
+    def _separate(self, name: Optional[str]) -> tuple[Optional[Any], Optional[str]]:
         """
         Get database name and schema name from schema if it contains a database name
             Format:
@@ -196,7 +196,7 @@ class DuckDBIdentifierPreparer(PGIdentifierPreparer):
             )
         return database_name, schema_name
 
-    def format_schema(self, name):
+    def format_schema(self, name: str) -> str:
         """Prepare a quoted schema name."""
         database_name, schema_name = self._separate(name)
         if database_name is None:
@@ -310,7 +310,7 @@ class Dialect(PGDialect_psycopg2):
         return [row[0] for row in rs]
 
     @cache  # type: ignore[call-arg]
-    def get_schema_names(self, connection: "Connection", **kw: "Any"):  # type: ignore[no-untyped-def]
+    def get_schema_names(self, connection: "Connection", **kw: Any):  # type: ignore[no-untyped-def]
         """
         Return unquoted database_name.schema_name unless either contains spaces or double quotes.
         In that case, escape double quotes and then wrap in double quotes.
@@ -332,7 +332,12 @@ class Dialect(PGDialect_psycopg2):
         qs = self.identifier_preparer.quote_schema
         return [qs(".".join(nspname)) for nspname in rs]
 
-    def _build_query_where(self, table_name=None, schema_name=None, database_name=None):
+    def _build_query_where(
+        self,
+        table_name: Optional[str] = None,
+        schema_name: Optional[str] = None,
+        database_name: Optional[str] = None,
+    ) -> Tuple[str, Dict[str, str]]:
         sql = ""
         params = {}
 
@@ -357,7 +362,7 @@ class Dialect(PGDialect_psycopg2):
         return sql, params
 
     @cache  # type: ignore[call-arg]
-    def get_table_names(self, connection: "Connection", schema=None, **kw: "Any"):  # type: ignore[no-untyped-def]
+    def get_table_names(self, connection: "Connection", schema=None, **kw: Any):  # type: ignore[no-untyped-def]
         """
         Return unquoted database_name.schema_name unless either contains spaces or double quotes.
         In that case, escape double quotes and then wrap in double quotes.
@@ -386,8 +391,14 @@ class Dialect(PGDialect_psycopg2):
             ) in rs
         ]
 
-    @cache
-    def get_table_oid(self, connection, table_name, schema=None, **kw):
+    @cache  # type: ignore[call-arg]
+    def get_table_oid(
+        self,
+        connection: "Connection",
+        table_name: str,
+        schema: Optional[str] = None,
+        **kw: Any,
+    ) -> int:
         """Fetch the oid for (database.)schema.table_name.
         The schema name can be formatted either as database.schema or just the schema name.
         In the latter scenario the schema associated with the default database is used.
@@ -407,7 +418,13 @@ class Dialect(PGDialect_psycopg2):
             raise NoSuchTableError(table_name)
         return table_oid
 
-    def has_table(self, connection, table_name, schema=None, **kw):
+    def has_table(
+        self,
+        connection: "Connection",
+        table_name: str,
+        schema: Optional[str] = None,
+        **kw: Any,
+    ) -> bool:
         try:
             return self.get_table_oid(connection, table_name, schema) is not None
         except NoSuchTableError:
@@ -453,20 +470,26 @@ class Dialect(PGDialect_psycopg2):
             self, cursor, statement, parameters, context
         )
 
-    @cache
-    def get_columns(self, connection, table_name, schema=None, **kw):
+    @cache  # type: ignore[call-arg]
+    def get_columns(
+        self,
+        connection: "Connection",
+        table_name: str,
+        schema: Optional[str] = None,
+        **kw: Any,
+    ) -> Any:
         _, schema = self.identifier_preparer._separate(schema)
         return super().get_columns(connection, table_name, schema=None, **kw)
 
-    @cache
+    @cache  # type: ignore[call-arg]
     def get_foreign_keys(
         self,
-        connection,
-        table_name,
-        schema=None,
-        postgresql_ignore_search_path=False,
-        **kw,
-    ):
+        connection: "Connection",
+        table_name: str,
+        schema: Optional[str] = None,
+        postgresql_ignore_search_path: bool = False,
+        **kw: Any,
+    ) -> Any:
         _, schema = self.identifier_preparer._separate(schema)
         return super().get_foreign_keys(
             connection,
@@ -476,13 +499,25 @@ class Dialect(PGDialect_psycopg2):
             **kw,
         )
 
-    @cache
-    def get_check_constraints(self, connection, table_name, schema=None, **kw):
+    @cache  # type: ignore[call-arg]
+    def get_check_constraints(
+        self,
+        connection: "Connection",
+        table_name: str,
+        schema: Optional[str] = None,
+        **kw: Any,
+    ) -> Any:
         _, schema = self.identifier_preparer._separate(schema)
         return super().get_check_constraints(connection, table_name, schema, **kw)
 
-    @cache
-    def get_unique_constraints(self, connection, table_name, schema=None, **kw):
+    @cache  # type: ignore[call-arg]
+    def get_unique_constraints(
+        self,
+        connection: "Connection",
+        table_name: str,
+        schema: Optional[str] = None,
+        **kw: Any,
+    ) -> Any:
         _, schema = self.identifier_preparer._separate(schema)
         return super().get_unique_constraints(connection, table_name, schema, **kw)
 

--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -182,7 +182,7 @@ def index_warning() -> None:
 
 
 class DuckDBIdentifierPreparer(PGIdentifierPreparer):
-    def _separate(self, name: Optional[str]) -> tuple[Optional[Any], Optional[str]]:
+    def _separate(self, name: Optional[str]) -> Tuple[Optional[Any], Optional[str]]:
         """
         Get database name and schema name from schema if it contains a database name
             Format:
@@ -310,7 +310,7 @@ class Dialect(PGDialect_psycopg2):
         return [row[0] for row in rs]
 
     @cache  # type: ignore[call-arg]
-    def get_schema_names(self, connection: "Connection", **kw: Any):  # type: ignore[no-untyped-def]
+    def get_schema_names(self, connection: "Connection", **kw: "Any"):  # type: ignore[no-untyped-def]
         """
         Return unquoted database_name.schema_name unless either contains spaces or double quotes.
         In that case, escape double quotes and then wrap in double quotes.
@@ -362,7 +362,7 @@ class Dialect(PGDialect_psycopg2):
         return sql, params
 
     @cache  # type: ignore[call-arg]
-    def get_table_names(self, connection: "Connection", schema=None, **kw: Any):  # type: ignore[no-untyped-def]
+    def get_table_names(self, connection: "Connection", schema=None, **kw: "Any"):  # type: ignore[no-untyped-def]
         """
         Return unquoted database_name.schema_name unless either contains spaces or double quotes.
         In that case, escape double quotes and then wrap in double quotes.
@@ -392,13 +392,13 @@ class Dialect(PGDialect_psycopg2):
         ]
 
     @cache  # type: ignore[call-arg]
-    def get_table_oid(
+    def get_table_oid(  # type: ignore[no-untyped-def]
         self,
         connection: "Connection",
         table_name: str,
-        schema: Optional[str] = None,
-        **kw: Any,
-    ) -> int:
+        schema: "Optional[str]" = None,
+        **kw: "Any",
+    ):
         """Fetch the oid for (database.)schema.table_name.
         The schema name can be formatted either as database.schema or just the schema name.
         In the latter scenario the schema associated with the default database is used.
@@ -471,25 +471,25 @@ class Dialect(PGDialect_psycopg2):
         )
 
     @cache  # type: ignore[call-arg]
-    def get_columns(
+    def get_columns(  # type: ignore[no-untyped-def]
         self,
         connection: "Connection",
         table_name: str,
-        schema: Optional[str] = None,
-        **kw: Any,
-    ) -> Any:
+        schema: "Optional[str]" = None,
+        **kw: "Any",
+    ):
         _, schema = self.identifier_preparer._separate(schema)
         return super().get_columns(connection, table_name, schema=None, **kw)
 
     @cache  # type: ignore[call-arg]
-    def get_foreign_keys(
+    def get_foreign_keys(  # type: ignore[no-untyped-def]
         self,
         connection: "Connection",
         table_name: str,
-        schema: Optional[str] = None,
+        schema: "Optional[str]" = None,
         postgresql_ignore_search_path: bool = False,
-        **kw: Any,
-    ) -> Any:
+        **kw: "Any",
+    ):
         _, schema = self.identifier_preparer._separate(schema)
         return super().get_foreign_keys(
             connection,
@@ -500,24 +500,24 @@ class Dialect(PGDialect_psycopg2):
         )
 
     @cache  # type: ignore[call-arg]
-    def get_check_constraints(
+    def get_check_constraints(  # type: ignore[no-untyped-def]
         self,
         connection: "Connection",
         table_name: str,
-        schema: Optional[str] = None,
-        **kw: Any,
-    ) -> Any:
+        schema: "Optional[str]" = None,
+        **kw: "Any",
+    ):
         _, schema = self.identifier_preparer._separate(schema)
         return super().get_check_constraints(connection, table_name, schema, **kw)
 
     @cache  # type: ignore[call-arg]
-    def get_unique_constraints(
+    def get_unique_constraints(  # type: ignore[no-untyped-def]
         self,
         connection: "Connection",
         table_name: str,
-        schema: Optional[str] = None,
-        **kw: Any,
-    ) -> Any:
+        schema: "Optional[str]" = None,
+        **kw: "Any",
+    ):
         _, schema = self.identifier_preparer._separate(schema)
         return super().get_unique_constraints(connection, table_name, schema, **kw)
 

--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -371,7 +371,7 @@ class Dialect(PGDialect_psycopg2):
             raise NoSuchTableError(table_name)
         return table_oid
 
-    def has_table(self, connection, table_name, schema=None):
+    def has_table(self, connection, table_name, schema=None, **kw):
         try:
             return self.get_table_oid(connection, table_name, schema) is not None
         except NoSuchTableError:

--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -470,61 +470,6 @@ class Dialect(PGDialect_psycopg2):
             self, cursor, statement, parameters, context
         )
 
-    @cache  # type: ignore[call-arg]
-    def get_columns(  # type: ignore[no-untyped-def]
-        self,
-        connection: "Connection",
-        table_name: str,
-        schema: "Optional[str]" = None,
-        **kw: "Any",
-    ):
-        # Support schema name with db name prefix
-        _, schema = self.identifier_preparer._separate(schema)
-        return super().get_columns(connection, table_name, schema=schema, **kw)
-
-    @cache  # type: ignore[call-arg]
-    def get_foreign_keys(  # type: ignore[no-untyped-def]
-        self,
-        connection: "Connection",
-        table_name: str,
-        schema: "Optional[str]" = None,
-        postgresql_ignore_search_path: bool = False,
-        **kw: "Any",
-    ):
-        # Support schema name with db name prefix
-        _, schema = self.identifier_preparer._separate(schema)
-        return super().get_foreign_keys(
-            connection,
-            table_name,
-            schema=schema,
-            postgresql_ignore_search_path=False,
-            **kw,
-        )
-
-    @cache  # type: ignore[call-arg]
-    def get_check_constraints(  # type: ignore[no-untyped-def]
-        self,
-        connection: "Connection",
-        table_name: str,
-        schema: "Optional[str]" = None,
-        **kw: "Any",
-    ):
-        # Support schema name with db name prefix
-        _, schema = self.identifier_preparer._separate(schema)
-        return super().get_check_constraints(connection, table_name, schema, **kw)
-
-    @cache  # type: ignore[call-arg]
-    def get_unique_constraints(  # type: ignore[no-untyped-def]
-        self,
-        connection: "Connection",
-        table_name: str,
-        schema: "Optional[str]" = None,
-        **kw: "Any",
-    ):
-        # Support schema name with db name prefix
-        _, schema = self.identifier_preparer._separate(schema)
-        return super().get_unique_constraints(connection, table_name, schema, **kw)
-
     # FIXME: this method is a hack around the fact that we use a single cursor for all queries inside a connection,
     #   and this is required to fix get_multi_columns
     def get_multi_columns(
@@ -558,8 +503,6 @@ class Dialect(PGDialect_psycopg2):
         SOFTWARE.
         """
 
-        # Support schema name with db name prefix
-        _, schema = self.identifier_preparer._separate(schema)
         has_filter_names, params = self._prepare_filter_names(filter_names)  # type: ignore[attr-defined]
         query = self._columns_query(schema, has_filter_names, scope, kind)  # type: ignore[attr-defined]
         rows = list(connection.execute(query, params).mappings())

--- a/duckdb_engine/tests/test_basic.py
+++ b/duckdb_engine/tests/test_basic.py
@@ -291,11 +291,12 @@ def test_get_columns(inspector: Inspector, session: Session) -> None:
     assert inspector.has_table("t1", '"daffy duck"."quack quack"')
     cols1 = inspector.get_columns("t1", None)
     cols2 = inspector.get_columns("t1", '"daffy duck"."quack quack"')
-    cols3 = inspector.get_columns("t1", '"daffy duck.quack quack"')
+    cols3 = inspector.get_columns("t1", 'daffy duck.quack quack')
     assert len(cols1) == 2
     assert cols1[0]["name"] == "i"
     assert cols1[1]["name"] == "j"
-    assert cols1 == cols2 == cols3
+    assert cols1[0]["name"] == cols2[0]["name"] == cols3[0]["name"]
+    assert cols1[1]["name"] == cols2[1]["name"] == cols3[1]["name"]
 
 
 def test_get_foreign_keys(inspector: Inspector) -> None:

--- a/duckdb_engine/tests/test_basic.py
+++ b/duckdb_engine/tests/test_basic.py
@@ -215,24 +215,23 @@ def test_get_table_names(inspector: Inspector, session: Session) -> None:
         """CREATE TABLE "daffy duck"."quack quack"."t1" (i INTEGER, j INTEGER);""",
         """CREATE TABLE "daffy duck"."quack quack"."t2" (i INTEGER, j INTEGER);""",
         """CREATE TABLE "t3" (i INTEGER, j INTEGER);""",
+        """CREATE SCHEMA "porky" """,
+        """CREATE TABLE "porky"."t4" (i INTEGER, j INTEGER);""",
     ]
     for cmd in cmds:
         session.execute(text(cmd))
         session.commit()
 
-    table_names = inspector.get_table_names(schema='"daffy duck"."quack quack"')
-    assert set(table_names) == {"t1", "t2"}
-    for table_name in table_names:
-        assert inspector.has_table(table_name, schema='"daffy duck"."quack quack"')
-    
-    table_names = inspector.get_table_names(schema='main')
-    assert "t3" in table_names
-    assert "t1" not in table_names
+    for schema, table_names in zip(
+        ['"daffy duck"."quack quack"', "main", "porky"], [["t1", "t2"], ["t3"], ["t4"]]
+    ):
+        _table_names = inspector.get_table_names(schema=schema)
+        assert set(_table_names).issuperset(set(table_names))
+        for _table_name in _table_names:
+            assert inspector.has_table(_table_name, schema)
 
     table_names_all = inspector.get_table_names()
-    assert "t1" in table_names_all
-    assert "t2" in table_names_all
-    assert "t3" in table_names_all
+    assert set(table_names_all).issuperset({"t1", "t2", "t3", "t4"})
     for table_name in table_names_all:
         assert inspector.has_table(table_name)
 

--- a/duckdb_engine/tests/test_basic.py
+++ b/duckdb_engine/tests/test_basic.py
@@ -214,6 +214,7 @@ def test_get_table_names(inspector: Inspector, session: Session) -> None:
         """CREATE SCHEMA "daffy duck"."quack quack" """,
         """CREATE TABLE "daffy duck"."quack quack"."t1" (i INTEGER, j INTEGER);""",
         """CREATE TABLE "daffy duck"."quack quack"."t2" (i INTEGER, j INTEGER);""",
+        """CREATE TABLE "t3" (i INTEGER, j INTEGER);""",
     ]
     for cmd in cmds:
         session.execute(text(cmd))
@@ -223,10 +224,15 @@ def test_get_table_names(inspector: Inspector, session: Session) -> None:
     assert set(table_names) == {"t1", "t2"}
     for table_name in table_names:
         assert inspector.has_table(table_name, schema='"daffy duck"."quack quack"')
+    
+    table_names = inspector.get_table_names(schema='main')
+    assert "t3" in table_names
+    assert "t1" not in table_names
 
     table_names_all = inspector.get_table_names()
     assert "t1" in table_names_all
     assert "t2" in table_names_all
+    assert "t3" in table_names_all
     for table_name in table_names_all:
         assert inspector.has_table(table_name)
 

--- a/duckdb_engine/tests/test_basic.py
+++ b/duckdb_engine/tests/test_basic.py
@@ -291,7 +291,7 @@ def test_get_columns(inspector: Inspector, session: Session) -> None:
     assert inspector.has_table("t1", '"daffy duck"."quack quack"')
     cols1 = inspector.get_columns("t1", None)
     cols2 = inspector.get_columns("t1", '"daffy duck"."quack quack"')
-    cols3 = inspector.get_columns("t1", 'daffy duck.quack quack')
+    cols3 = inspector.get_columns("t1", "daffy duck.quack quack")
     assert len(cols1) == 2
     assert cols1[0]["name"] == "i"
     assert cols1[1]["name"] == "j"


### PR DESCRIPTION
With the introduction of PR #835 a user might want to fully specify a schema with the database name as prefix, i.e. `"my db"."my schema"`.

This PR fixes a bug that currently prevents usage of `Dialect.has_table`, `Dialect.get_table_names`, `Dialect.get_columns`, `Dialect.get_foreign_keys` and `Dialect.get_check_constraints` when using said fully specified schema name.

I also refactored `test_get_schema_names` so there is a separate test for `get_table_names`.

Edit: This fixes https://github.com/duckdb/duckdb/issues/10033