### PR TITLE
Add duckdb_engine/sqlalchemy version info to DuckDB user_agent

### DIFF
--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -41,6 +41,7 @@ __version__ = "0.10.0"
 sqlalchemy_version = sqlalchemy.__version__
 duckdb_version: str = duckdb.__version__  # type: ignore[attr-defined]
 supports_attach: bool = duckdb_version >= "0.7.0"
+supports_user_agent: bool = duckdb_version >= "0.9.2"
 
 if TYPE_CHECKING:
     from sqlalchemy.base import Connection
@@ -252,6 +253,10 @@ class Dialect(PGDialect_psycopg2):
         config.update(cparams.pop("url_config", {}))
 
         ext = {k: config.pop(k) for k in list(config) if k not in core_keys}
+        if supports_user_agent:
+            user_agent = f"duckdb_engine/{__version__}(sqlalchemy/{sqlalchemy_version})"
+            if ('custom_user_agent' in config): user_agent = f"{user_agent} {config['custom_user_agent']}"
+            config['custom_user_agent'] = user_agent
 
         conn = duckdb.connect(*cargs, **cparams)
 

--- a/duckdb_engine/tests/test_basic.py
+++ b/duckdb_engine/tests/test_basic.py
@@ -36,7 +36,7 @@ from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Session, relationship, sessionmaker
 
-from .. import DBAPI, Dialect, supports_attach
+from .. import DBAPI, Dialect, supports_attach, supports_user_agent
 
 try:
     # sqlalchemy 2
@@ -480,6 +480,10 @@ def test_url_config_and_dict_config() -> None:
         assert worker_threads == 123
         assert memory_limit in ("500.0MB", "476.8 MiB")
 
+@mark.skipif(
+    supports_user_agent is False,
+    reason="custom_user_agent is not supported for DuckDB version < 0.9.2",
+)
 def test_user_agent() -> None:
     eng = create_engine("duckdb:///:memory:")
 
@@ -489,6 +493,10 @@ def test_user_agent() -> None:
         assert row is not None
         assert re.match(r'duckdb/.*(.*) python duckdb_engine/.*(sqlalchemy/.*)', row[0])
 
+@mark.skipif(
+    supports_user_agent is False,
+    reason="custom_user_agent is not supported for DuckDB version < 0.9.2",
+)
 def test_user_agent_with_custom_user_agent() -> None:
     eng = create_engine("duckdb:///:memory:", connect_args={"config": {"custom_user_agent": "custom"}})
 


### PR DESCRIPTION
DuckDB supports `custom_user_agent` property since DuckDB v0.9.2. 
This PR adds version information for both `duckdb_engine` and `sqlalchemy`, since they are independent from each other.