### PR TITLE
fix: relax pin on `packaging`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1571,4 +1571,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "62faf09f84b568f1377ac2d858e5522a582b6b656f2f9a8eda1946f4f154cb71"
+content-hash = "699c7ada04a278e08d0aabc90bb65facf110a1c7e4634df1855188859b8b4547"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/Mause/duckdb_engine"
 python = ">=3.8,<4"
 duckdb = ">=0.5.0"
 sqlalchemy = ">=1.3.22"
-packaging = "^21"
+packaging = ">=21"
 
 [tool.poetry.group.dev.dependencies]
 numpy = "*"


### PR DESCRIPTION
The current pin is overly strict based on the usage of `packaging` within this project. It causes clashes with other packages which may depend on newer versions of `packaging`.