### PR TITLE
Pass user config option via database name

### DIFF
--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -1,4 +1,6 @@
+import os
 import re
+import uuid
 import warnings
 from typing import (
     TYPE_CHECKING,
@@ -476,6 +478,8 @@ class Dialect(PGDialect_psycopg2):
     def create_connect_args(self, url: URL) -> Tuple[tuple, dict]:
         opts = url.translate_connect_args(database="database")
         opts["url_config"] = dict(url.query)
+        if opts["url_config"].pop("no_cache", False):
+            opts["database"] += f"?no_cache={uuid.uuid4()}"
         return (), opts
 
     @classmethod

--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -478,8 +478,9 @@ class Dialect(PGDialect_psycopg2):
     def create_connect_args(self, url: URL) -> Tuple[tuple, dict]:
         opts = url.translate_connect_args(database="database")
         opts["url_config"] = dict(url.query)
-        if opts["url_config"].pop("no_cache", False):
-            opts["database"] += f"?no_cache={uuid.uuid4()}"
+        user = opts["url_config"].pop("user", None)
+        if user is not None:
+            opts["database"] += f"?user={user}"
         return (), opts
 
     @classmethod

--- a/duckdb_engine/tests/test_basic.py
+++ b/duckdb_engine/tests/test_basic.py
@@ -622,8 +622,8 @@ def test_with_cache(tmp_path: Path) -> None:
 
 def test_no_cache(tmp_path: Path) -> None:
     tmp_db_path = str(tmp_path / "db_no_cache")
-    engine1 = create_engine(f"duckdb:///{tmp_db_path}?threads=1")
-    engine2 = create_engine(f"duckdb:///{tmp_db_path}?threads=2&no_cache=true")
+    engine1 = create_engine(f"duckdb:///{tmp_db_path}?threads=1&user=1")
+    engine2 = create_engine(f"duckdb:///{tmp_db_path}?threads=2&user=2")
     with engine1.connect() as conn1:
         with engine2.connect() as conn2:
             res1 = conn1.execute(text("select value from duckdb_settings() where name = 'threads'")).fetchall()


### PR DESCRIPTION
In DuckDB, database connections are cached by unique database name but not by unique configuration settings. This PR removes the `user` config option from the config and appends it to the database name (i.e. `database_name?user=foo`) such that we can disable the cache.