### PR TITLE
docs: use `read_only=False` so that example doesn't raise an exception.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can configure DuckDB by passing `connect_args` to the create_engine function
 create_engine(
     'duckdb:///:memory:',
     connect_args={
-        'read_only': True,
+        'read_only': False,
         'config': {
             'memory_limit': '500mb'
         }


### PR DESCRIPTION
I tried to run a query using the example connection from the README and it raised an error.

This change allows running a query using the example connection attributes:
```python
engine = sa.create_engine(
    'duckdb:///:memory:',
    connect_args={
        'read_only': True,
        'config': {
            'memory_limit': '500mb'
        }
    }
)
with engine.connect() as conn:
    res = conn.execute(sa.text("select 1")).scalar_one()
```
```python-traceback
CatalogException: Catalog Error: Cannot launch in-memory database in read-only mode!
<snip>
The above exception was the direct cause of the following exception:
<snip>
ProgrammingError: (duckdb.duckdb.CatalogException) Catalog Error: Cannot launch in-memory database in read-only mode!
(Background on this error at: https://sqlalche.me/e/20/f405)
```
