### PR TITLE
fix: avoid mutating caller's connect args (don't accumulate user_agents)

### DIFF
--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -261,7 +261,8 @@ class Dialect(PGDialect_psycopg2):
     def connect(self, *cargs: Any, **cparams: Any) -> "Connection":
         core_keys = get_core_config()
         preload_extensions = cparams.pop("preload_extensions", [])
-        config = cparams.setdefault("config", {})
+        config = dict(cparams.get("config", {}))
+        cparams["config"] = config
         config.update(cparams.pop("url_config", {}))
 
         ext = {k: config.pop(k) for k in list(config) if k not in core_keys}

--- a/duckdb_engine/tests/test_basic.py
+++ b/duckdb_engine/tests/test_basic.py
@@ -539,9 +539,8 @@ def test_user_agent() -> None:
     reason="custom_user_agent is not supported for DuckDB version < 0.9.2",
 )
 def test_user_agent_with_custom_user_agent() -> None:
-    eng = create_engine(
-        "duckdb:///:memory:", connect_args={"config": {"custom_user_agent": "custom"}}
-    )
+    connect_args = {"config": {"custom_user_agent": "custom"}}
+    eng = create_engine("duckdb:///:memory:", connect_args=connect_args)
 
     with eng.connect() as conn:
         res = conn.execute(text("PRAGMA USER_AGENT"))
@@ -550,6 +549,9 @@ def test_user_agent_with_custom_user_agent() -> None:
         assert re.match(
             r"duckdb/.*(.*) python duckdb_engine/.*(sqlalchemy/.*) custom", row[0]
         )
+
+    # Check that connect hasn't mutated the caller's data.
+    assert connect_args["config"]["custom_user_agent"] == "custom"
 
 
 def test_do_ping(tmp_path: Path, caplog: LogCaptureFixture) -> None:


### PR DESCRIPTION
`connect` mutates the config dictionary passed to `engine.create`.
Notably, each time it is called the `custom_user_agent` grows.
This PR clones the config and modifies the clone.