### PR TITLE
fix: add supported MotherDuck connection string parameters

### DIFF
--- a/duckdb_engine/config.py
+++ b/duckdb_engine/config.py
@@ -11,13 +11,16 @@ TYPES: Dict[Type, TypeEngine] = {int: Integer(), str: String(), bool: Boolean()}
 
 @lru_cache()
 def get_core_config() -> Set[str]:
+    # List of connection string parameters that are supported by MotherDuck
+    # See: https://motherduck.com/docs/key-tasks/authenticating-and-connecting-to-motherduck/authenticating-to-motherduck/
+    motherduck_config_keys = {"motherduck_token", "attach_mode", "saas_mode"}
+
     rows = (
         duckdb.connect(":memory:")
         .execute("SELECT name FROM duckdb_settings()")
         .fetchall()
     )
-    # special case for motherduck here - they accept this config at extension load time
-    return {name for (name,) in rows} | {"motherduck_token"}
+    return {name for (name,) in rows} | motherduck_config_keys
 
 
 def apply_config(


### PR DESCRIPTION
Hey @Mause,

Thanks so much for creating the SQLAlchemy driver for DuckDB 🙌 

We're going to use the driver to connect to MotherDuck, so we would like to have support for the `attach_mode` and `saas_mode` connection string parameters. They are useful for our production-level applications where we need to restrict the privileges of the MotherDuck connection.

See for details:
https://motherduck.com/docs/key-tasks/authenticating-and-connecting-to-motherduck/authenticating-to-motherduck/#using-connection-string-parameters

Do you think it would be possible to merge these in? Let me know if I can do anything else to support.

\- Finn