### PR TITLE
dev: update to sqlalchemy 2.0 in tests, example, and typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
           - "duckdb==0.10.1"
           - "pytest==6.2.4"
           - "hypothesis==6.14.1"
-          - "sqlalchemy[mypy]==1.4.46"
+          - "sqlalchemy==2.0.39"
           - "types-setuptools==57.4.17"
           - "nox"
   - repo: https://github.com/tox-dev/tox-ini-fmt

--- a/README.md
+++ b/README.md
@@ -37,10 +37,12 @@ Once you've installed this package, you should be able to just use it, as SQLAlc
 
 ```python
 from sqlalchemy import Column, Integer, Sequence, String, create_engine
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.orm.session import Session
 
-Base = declarative_base()
+
+class Base(DeclarativeBase):
+    pass
 
 
 class FakeModel(Base):  # type: ignore

--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -8,8 +8,8 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Literal,
     Optional,
-    Set,
     Tuple,
     Type,
 )
@@ -27,6 +27,7 @@ from sqlalchemy.dialects.postgresql.base import (
 )
 from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
 from sqlalchemy.engine.default import DefaultDialect
+from sqlalchemy.engine.interfaces import DBAPIConnection
 from sqlalchemy.engine.interfaces import Dialect as RootDialect
 from sqlalchemy.engine.reflection import cache
 from sqlalchemy.engine.url import URL
@@ -46,9 +47,13 @@ supports_attach: bool = duckdb_version >= "0.7.0"
 supports_user_agent: bool = duckdb_version >= "0.9.2"
 
 if TYPE_CHECKING:
-    from sqlalchemy.base import Connection
-    from sqlalchemy.engine.interfaces import _IndexDict
-    from sqlalchemy.sql.type_api import _ResultProcessor
+    from sqlalchemy import Connection
+    from sqlalchemy.engine.interfaces import (
+        ReflectedCheckConstraint,
+        ReflectedColumn,
+        ReflectedIndex,
+    )
+    from sqlalchemy.sql.type_api import _ResultProcessorType
 
 register_extension_types()
 
@@ -81,7 +86,7 @@ class DBAPI:
 class DuckDBInspector(PGInspector):
     def get_check_constraints(
         self, table_name: str, schema: Optional[str] = None, **kw: Any
-    ) -> List[Dict[str, Any]]:
+    ) -> List[ReflectedCheckConstraint]:
         try:
             return super().get_check_constraints(table_name, schema, **kw)
         except Exception as e:
@@ -160,7 +165,7 @@ class CursorWrapper:
                 raise e
 
     @property
-    def connection(self) -> "Connection":
+    def connection(self) -> "ConnectionWrapper":
         return self.__connection_wrapper
 
     def close(self) -> None:
@@ -189,7 +194,7 @@ def index_warning() -> None:
 
 class DuckDBIdentifierPreparer(PGIdentifierPreparer):
     def __init__(self, dialect: "Dialect", **kwargs: Any) -> None:
-        super().__init__(dialect, **kwargs)
+        super().__init__(dialect, **kwargs)  # type: ignore[no-untyped-call]
 
         self.reserved_words.update(
             {
@@ -233,10 +238,10 @@ class DuckDBIdentifierPreparer(PGIdentifierPreparer):
 
 class DuckDBNullType(sqltypes.NullType):
     def result_processor(
-        self, dialect: RootDialect, coltype: sqltypes.TypeEngine
-    ) -> Optional["_ResultProcessor"]:
+        self, dialect: RootDialect, coltype: object
+    ) -> Optional[_ResultProcessorType]:
         if coltype == "JSON":
-            return sqltypes.JSON().result_processor(dialect, coltype)
+            return sqltypes.JSON().result_processor(dialect, coltype)  # type: ignore[no-untyped-call]
         else:
             return super().result_processor(dialect, coltype)
 
@@ -251,7 +256,7 @@ class Dialect(PGDialect_psycopg2):
     supports_server_side_cursors = False
     div_is_floordiv = False  # TODO: tweak this to be based on DuckDB version
     inspector = DuckDBInspector
-    colspecs = util.update_copy(
+    colspecs = util.update_copy(  # type: ignore[no-untyped-call]
         PGDialect.colspecs,
         {
             # the psycopg2 driver registers a _PGNumeric with custom logic for
@@ -261,26 +266,26 @@ class Dialect(PGDialect_psycopg2):
             UUID: UUID,
         },
     )
-    ischema_names = util.update_copy(
+    ischema_names = util.update_copy(  # type: ignore[no-untyped-call]
         PGDialect.ischema_names,
         ISCHEMA_NAMES,
     )
-    preparer = DuckDBIdentifierPreparer
+    preparer = DuckDBIdentifierPreparer  # type: ignore[assignment]
     identifier_preparer: DuckDBIdentifierPreparer
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         kwargs["use_native_hstore"] = False
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)  # type: ignore[no-untyped-call]
 
     def type_descriptor(self, typeobj: Type[sqltypes.TypeEngine]) -> Any:  # type: ignore[override]
-        res = super().type_descriptor(typeobj)
+        res = super().type_descriptor(typeobj)  # type: ignore[no-untyped-call]
 
         if isinstance(res, sqltypes.NullType):
             return DuckDBNullType()
 
         return res
 
-    def connect(self, *cargs: Any, **cparams: Any) -> "Connection":
+    def connect(self, *cargs: Any, **cparams: Any) -> "ConnectionWrapper":  # type: ignore[override]
         core_keys = get_core_config()
         preload_extensions = cparams.pop("preload_extensions", [])
         config = dict(cparams.get("config", {}))
@@ -314,18 +319,27 @@ class Dialect(PGDialect_psycopg2):
             return pool.QueuePool
 
     @staticmethod
-    def dbapi(**kwargs: Any) -> Type[DBAPI]:
+    def dbapi(**kwargs: Any) -> Type[DBAPI]:  # type: ignore[override]
         return DBAPI
 
     def _get_server_version_info(self, connection: "Connection") -> Tuple[int, int]:
         return (8, 0)
 
-    def get_default_isolation_level(self, connection: "Connection") -> None:
+    def get_default_isolation_level(
+        self, connection: "DBAPIConnection"
+    ) -> Literal[
+        "SERIALIZABLE",
+        "REPEATABLE READ",
+        "READ COMMITTED",
+        "READ UNCOMMITTED",
+        "AUTOCOMMIT",
+    ]:
+        # def get_default_isolation_level(self, connection):
         raise NotImplementedError()
 
-    def do_rollback(self, connection: "Connection") -> None:
+    def do_rollback(self, connection: "Connection") -> None:  # type: ignore[override]
         try:
-            super().do_rollback(connection)
+            super().do_rollback(connection)  # type: ignore[no-untyped-call]
         except DBAPI.TransactionException as e:
             if (
                 e.args[0]
@@ -333,7 +347,7 @@ class Dialect(PGDialect_psycopg2):
             ):
                 raise e
 
-    def do_begin(self, connection: "Connection") -> None:
+    def do_begin(self, connection: "Connection") -> None:  # type: ignore[override]
         connection.begin()
 
     def get_view_names(
@@ -367,7 +381,7 @@ class Dialect(PGDialect_psycopg2):
         rs = connection.execute(text(s), params)
         return [view for (view,) in rs]
 
-    @cache  # type: ignore[call-arg]
+    @cache
     def get_schema_names(self, connection: "Connection", **kw: "Any"):  # type: ignore[no-untyped-def]
         """
         Return unquoted database_name.schema_name unless either contains spaces or double quotes.
@@ -377,7 +391,7 @@ class Dialect(PGDialect_psycopg2):
         """
 
         if not supports_attach:
-            return super().get_schema_names(connection, **kw)
+            return super().get_schema_names(connection, **kw)  # type: ignore[no-untyped-call]
 
         s = """
             SELECT database_name, schema_name AS nspname
@@ -419,8 +433,10 @@ class Dialect(PGDialect_psycopg2):
 
         return sql, params
 
-    @cache  # type: ignore[call-arg]
-    def get_table_names(self, connection: "Connection", schema=None, **kw: "Any"):  # type: ignore[no-untyped-def]
+    @cache
+    def get_table_names(
+        self, connection: "Connection", schema: Optional[str] = None, **kw: "Any"
+    ) -> List[str]:
         """
         Return unquoted database_name.schema_name unless either contains spaces or double quotes.
         In that case, escape double quotes and then wrap in double quotes.
@@ -429,7 +445,7 @@ class Dialect(PGDialect_psycopg2):
         """
 
         if not supports_attach:
-            return super().get_table_names(connection, schema, **kw)
+            return super().get_table_names(connection, schema, **kw)  # type: ignore[no-untyped-call]
 
         s = """
             SELECT database_name, schema_name, table_name
@@ -449,14 +465,14 @@ class Dialect(PGDialect_psycopg2):
             ) in rs
         ]
 
-    @cache  # type: ignore[call-arg]
-    def get_table_oid(  # type: ignore[no-untyped-def]
+    @cache
+    def get_table_oid(
         self,
         connection: "Connection",
         table_name: str,
         schema: "Optional[str]" = None,
         **kw: "Any",
-    ):
+    ) -> str:
         """Fetch the oid for (database.)schema.table_name.
         The schema name can be formatted either as database.schema or just the schema name.
         In the latter scenario the schema associated with the default database is used.
@@ -497,12 +513,12 @@ class Dialect(PGDialect_psycopg2):
         table_name: str,
         schema: Optional[str] = None,
         **kw: Any,
-    ) -> List["_IndexDict"]:
+    ) -> List[ReflectedIndex]:
         index_warning()
         return []
 
     # the following methods are for SQLA2 compatibility
-    def get_multi_indexes(
+    def get_multi_indexes(  # type: ignore[override]
         self,
         connection: "Connection",
         schema: Optional[str] = None,
@@ -513,7 +529,7 @@ class Dialect(PGDialect_psycopg2):
         return []
 
     def initialize(self, connection: "Connection") -> None:
-        DefaultDialect.initialize(self, connection)
+        DefaultDialect.initialize(self, connection)  # type: ignore[no-untyped-call]
 
     def create_connect_args(self, url: URL) -> Tuple[tuple, dict]:
         opts = url.translate_connect_args(database="database")
@@ -524,13 +540,13 @@ class Dialect(PGDialect_psycopg2):
         return (), opts
 
     @classmethod
-    def import_dbapi(cls: Type["Dialect"]) -> Type[DBAPI]:
+    def import_dbapi(cls: Type["Dialect"]) -> Type[DBAPI]:  # type: ignore[override]
         return cls.dbapi()
 
     def do_executemany(
         self, cursor: Any, statement: Any, parameters: Any, context: Optional[Any] = ...
     ) -> None:
-        return DefaultDialect.do_executemany(
+        return DefaultDialect.do_executemany(  # type: ignore[no-untyped-call]
             self, cursor, statement, parameters, context
         )
 
@@ -559,15 +575,16 @@ class Dialect(PGDialect_psycopg2):
 
     # FIXME: this method is a hack around the fact that we use a single cursor for all queries inside a connection,
     #   and this is required to fix get_multi_columns
-    def get_multi_columns(
+    def get_multi_columns(  # type: ignore[override]
         self,
         connection: "Connection",
+        *,
         schema: Optional[str] = None,
-        filter_names: Optional[Set[str]] = None,
+        filter_names: Optional[Collection[str]] = None,
         scope: Optional[str] = None,
         kind: Optional[Tuple[str, ...]] = None,
         **kw: Any,
-    ) -> List:
+    ) -> Iterable[tuple[tuple[str | None, str], list[ReflectedColumn]]]:
         """
         Copyright 2005-2023 SQLAlchemy authors and contributors <see AUTHORS file>.
 
@@ -590,8 +607,8 @@ class Dialect(PGDialect_psycopg2):
         SOFTWARE.
         """
 
-        has_filter_names, params = self._prepare_filter_names(filter_names)  # type: ignore[attr-defined]
-        query = self._columns_query(schema, has_filter_names, scope, kind)  # type: ignore[attr-defined]
+        has_filter_names, params = self._prepare_filter_names(filter_names)  # type: ignore[no-untyped-call]
+        query = self._columns_query(schema, has_filter_names, scope, kind)
         rows = list(connection.execute(query, params).mappings())
 
         # dictionary with (name, ) if default search path or (schema, name)
@@ -615,12 +632,12 @@ class Dialect(PGDialect_psycopg2):
                 if rec["visible"]
                 else ((rec["schema"], rec["name"]), rec)
             )
-            for rec in self._load_enums(  # type: ignore[attr-defined]
+            for rec in self._load_enums(  # type: ignore[no-untyped-call]
                 connection, schema="*", info_cache=kw.get("info_cache")
             )
         )
 
-        columns = self._get_columns_info(rows, domains, enums, schema)  # type: ignore[attr-defined]
+        columns = self._get_columns_info(rows, domains, enums, schema)  # type: ignore[no-untyped-call]
 
         return columns.items()
 
@@ -631,7 +648,7 @@ class Dialect(PGDialect_psycopg2):
         self, schema: str, has_filter_names: bool, scope: Any, kind: Any
     ):
         if sqlalchemy.__version__ >= "2.0.36":
-            from sqlalchemy.dialects.postgresql import (  # type: ignore[attr-defined]
+            from sqlalchemy.dialects.postgresql import (
                 pg_catalog,
             )
 
@@ -671,15 +688,15 @@ class Dialect(PGDialect_psycopg2):
 
 
 if sqlalchemy.__version__ >= "2.0.14":
-    from sqlalchemy import TryCast  # type: ignore[attr-defined]
+    from sqlalchemy import TryCast
 
-    @compiles(TryCast, "duckdb")  # type: ignore[misc]
+    @compiles(TryCast, "duckdb")
     def visit_try_cast(
         instance: TryCast,
         compiler: PGTypeCompiler,
         **kw: Any,
     ) -> str:
         return "TRY_CAST({} AS {})".format(
-            compiler.process(instance.clause, **kw),
-            compiler.process(instance.typeclause, **kw),
+            compiler.process(instance.clause, **kw),  # type: ignore[arg-type]
+            compiler.process(instance.typeclause, **kw),  # type: ignore[arg-type]
         )

--- a/duckdb_engine/datatypes.py
+++ b/duckdb_engine/datatypes.py
@@ -163,7 +163,7 @@ class Map(TypeEngine):
         )
 
     def result_processor(
-        self, dialect: Dialect, coltype: str
+        self, dialect: Dialect, coltype: object
     ) -> Optional[Callable[[Optional[dict]], Optional[dict]]]:
         if IS_GT_1:
             return lambda value: value
@@ -226,7 +226,7 @@ def register_extension_types() -> None:
         compiles(subclass, "duckdb")(compile_uint)
 
 
-@compiles(Struct, "duckdb")  # type: ignore[misc]
+@compiles(Struct, "duckdb")
 def visit_struct(
     instance: Struct,
     compiler: PGTypeCompiler,
@@ -236,7 +236,7 @@ def visit_struct(
     return "STRUCT" + struct_or_union(instance, compiler, identifier_preparer, **kw)
 
 
-@compiles(Union, "duckdb")  # type: ignore[misc]
+@compiles(Union, "duckdb")
 def visit_union(
     instance: Union,
     compiler: PGTypeCompiler,
@@ -276,7 +276,7 @@ def process_type(
     return compiler.process(type_api.to_instance(value), **kw)
 
 
-@compiles(Map, "duckdb")  # type: ignore[misc]
+@compiles(Map, "duckdb")
 def visit_map(instance: Map, compiler: PGTypeCompiler, **kw: Any) -> str:
     return "MAP({}, {})".format(
         process_type(instance.key_type, compiler, **kw),

--- a/duckdb_engine/tests/conftest.py
+++ b/duckdb_engine/tests/conftest.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Generator, TypeVar
 
 from pytest import fixture, raises
 from sqlalchemy import create_engine
-from sqlalchemy.dialects import registry  # type: ignore
+from sqlalchemy.dialects import registry
 from sqlalchemy.engine import Dialect, Engine
 from sqlalchemy.engine.base import Connection
 from sqlalchemy.orm import Session, sessionmaker

--- a/duckdb_engine/tests/test_integration.py
+++ b/duckdb_engine/tests/test_integration.py
@@ -11,7 +11,7 @@ df = pd.DataFrame([{"a": 1}])
 
 @mark.skipif(not hasattr(Connection, "exec_driver_sql"), reason="Needs exec_driver_sql")
 def test_register_driver(conn: Connection) -> None:
-    conn.exec_driver_sql("register", ("test_df_driver", df))  # type: ignore[arg-type]
+    conn.exec_driver_sql("register", ("test_df_driver", df))
     conn.execute(text("select * from test_df_driver"))
 
 

--- a/duckdb_engine/tests/test_pyarrow.py
+++ b/duckdb_engine/tests/test_pyarrow.py
@@ -38,9 +38,9 @@ def test_fetch_arrow() -> None:
             {"label": ["xx", "yy", "zz"], "value": [-1.0, 2.5, 6.0]}
         )
         res = con.execute(stmt).cursor.fetch_record_batch(rows_per_batch=2)
-        assert res.read_next_batch() == RecordBatch.from_pydict(
+        assert res.read_next_batch() == RecordBatch.from_pydict(  # type: ignore[attr-defined]
             {"label": ["xx", "yy"], "value": [-1.0, 2.5]}
         )
-        assert res.read_next_batch() == RecordBatch.from_pydict(
+        assert res.read_next_batch() == RecordBatch.from_pydict(  # type: ignore[attr-defined]
             {"label": ["zz"], "value": [6.0]}
         )

--- a/poetry.lock
+++ b/poetry.lock
@@ -386,7 +386,7 @@ description = "Lightweight in-process concurrent programming"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 groups = ["main", "dev"]
-markers = "platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\""
+markers = "python_version < \"3.14\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"
 files = [
     {file = "greenlet-1.1.0-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:60848099b76467ef09b62b0f4512e7e6f0a2c977357a036de602b653667f5f4c"},
     {file = "greenlet-1.1.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:f42ad188466d946f1b3afc0a9e1a266ac8926461ee0786c06baac6bd71f8a6f3"},
@@ -1450,98 +1450,99 @@ files = [
 
 [[package]]
 name = "sqlalchemy"
-version = "1.4.54"
+version = "2.0.39"
 description = "Database Abstraction Library"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+python-versions = ">=3.7"
 groups = ["main", "dev"]
 files = [
-    {file = "SQLAlchemy-1.4.54-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:af00236fe21c4d4f4c227b6ccc19b44c594160cc3ff28d104cdce85855369277"},
-    {file = "SQLAlchemy-1.4.54-cp310-cp310-manylinux1_x86_64.manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_5_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1183599e25fa38a1a322294b949da02b4f0da13dbc2688ef9dbe746df573f8a6"},
-    {file = "SQLAlchemy-1.4.54-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1990d5a6a5dc358a0894c8ca02043fb9a5ad9538422001fb2826e91c50f1d539"},
-    {file = "SQLAlchemy-1.4.54-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:14b3f4783275339170984cadda66e3ec011cce87b405968dc8d51cf0f9997b0d"},
-    {file = "SQLAlchemy-1.4.54-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b24364150738ce488333b3fb48bfa14c189a66de41cd632796fbcacb26b4585"},
-    {file = "SQLAlchemy-1.4.54-cp310-cp310-win32.whl", hash = "sha256:a8a72259a1652f192c68377be7011eac3c463e9892ef2948828c7d58e4829988"},
-    {file = "SQLAlchemy-1.4.54-cp310-cp310-win_amd64.whl", hash = "sha256:b67589f7955924865344e6eacfdcf70675e64f36800a576aa5e961f0008cde2a"},
-    {file = "SQLAlchemy-1.4.54-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b05e0626ec1c391432eabb47a8abd3bf199fb74bfde7cc44a26d2b1b352c2c6e"},
-    {file = "SQLAlchemy-1.4.54-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:13e91d6892b5fcb94a36ba061fb7a1f03d0185ed9d8a77c84ba389e5bb05e936"},
-    {file = "SQLAlchemy-1.4.54-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb59a11689ff3c58e7652260127f9e34f7f45478a2f3ef831ab6db7bcd72108f"},
-    {file = "SQLAlchemy-1.4.54-cp311-cp311-win32.whl", hash = "sha256:1390ca2d301a2708fd4425c6d75528d22f26b8f5cbc9faba1ddca136671432bc"},
-    {file = "SQLAlchemy-1.4.54-cp311-cp311-win_amd64.whl", hash = "sha256:2b37931eac4b837c45e2522066bda221ac6d80e78922fb77c75eb12e4dbcdee5"},
-    {file = "SQLAlchemy-1.4.54-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:3f01c2629a7d6b30d8afe0326b8c649b74825a0e1ebdcb01e8ffd1c920deb07d"},
-    {file = "SQLAlchemy-1.4.54-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c24dd161c06992ed16c5e528a75878edbaeced5660c3db88c820f1f0d3fe1f4"},
-    {file = "SQLAlchemy-1.4.54-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b5e0d47d619c739bdc636bbe007da4519fc953393304a5943e0b5aec96c9877c"},
-    {file = "SQLAlchemy-1.4.54-cp312-cp312-win32.whl", hash = "sha256:12bc0141b245918b80d9d17eca94663dbd3f5266ac77a0be60750f36102bbb0f"},
-    {file = "SQLAlchemy-1.4.54-cp312-cp312-win_amd64.whl", hash = "sha256:f941aaf15f47f316123e1933f9ea91a6efda73a161a6ab6046d1cde37be62c88"},
-    {file = "SQLAlchemy-1.4.54-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:a41611835010ed4ea4c7aed1da5b58aac78ee7e70932a91ed2705a7b38e40f52"},
-    {file = "SQLAlchemy-1.4.54-cp36-cp36m-manylinux1_x86_64.manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_5_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e8c1b9ecaf9f2590337d5622189aeb2f0dbc54ba0232fa0856cf390957584a9"},
-    {file = "SQLAlchemy-1.4.54-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0de620f978ca273ce027769dc8db7e6ee72631796187adc8471b3c76091b809e"},
-    {file = "SQLAlchemy-1.4.54-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c5a2530400a6e7e68fd1552a55515de6a4559122e495f73554a51cedafc11669"},
-    {file = "SQLAlchemy-1.4.54-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d0cf7076c8578b3de4e43a046cc7a1af8466e1c3f5e64167189fe8958a4f9c02"},
-    {file = "SQLAlchemy-1.4.54-cp37-cp37m-macosx_11_0_x86_64.whl", hash = "sha256:f1e1b92ee4ee9ffc68624ace218b89ca5ca667607ccee4541a90cc44999b9aea"},
-    {file = "SQLAlchemy-1.4.54-cp37-cp37m-manylinux1_x86_64.manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_5_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:41cffc63c7c83dfc30c4cab5b4308ba74440a9633c4509c51a0c52431fb0f8ab"},
-    {file = "SQLAlchemy-1.4.54-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5933c45d11cbd9694b1540aa9076816cc7406964c7b16a380fd84d3a5fe3241"},
-    {file = "SQLAlchemy-1.4.54-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cafe0ba3a96d0845121433cffa2b9232844a2609fce694fcc02f3f31214ece28"},
-    {file = "SQLAlchemy-1.4.54-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a19f816f4702d7b1951d7576026c7124b9bfb64a9543e571774cf517b7a50b29"},
-    {file = "SQLAlchemy-1.4.54-cp37-cp37m-win32.whl", hash = "sha256:76c2ba7b5a09863d0a8166fbc753af96d561818c572dbaf697c52095938e7be4"},
-    {file = "SQLAlchemy-1.4.54-cp37-cp37m-win_amd64.whl", hash = "sha256:a86b0e4be775902a5496af4fb1b60d8a2a457d78f531458d294360b8637bb014"},
-    {file = "SQLAlchemy-1.4.54-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:a49730afb716f3f675755afec109895cab95bc9875db7ffe2e42c1b1c6279482"},
-    {file = "SQLAlchemy-1.4.54-cp38-cp38-manylinux1_x86_64.manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_5_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26e78444bc77d089e62874dc74df05a5c71f01ac598010a327881a48408d0064"},
-    {file = "SQLAlchemy-1.4.54-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02d2ecb9508f16ab9c5af466dfe5a88e26adf2e1a8d1c56eb616396ccae2c186"},
-    {file = "SQLAlchemy-1.4.54-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:394b0135900b62dbf63e4809cdc8ac923182af2816d06ea61cd6763943c2cc05"},
-    {file = "SQLAlchemy-1.4.54-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ed3576675c187e3baa80b02c4c9d0edfab78eff4e89dd9da736b921333a2432"},
-    {file = "SQLAlchemy-1.4.54-cp38-cp38-win32.whl", hash = "sha256:fc9ffd9a38e21fad3e8c5a88926d57f94a32546e937e0be46142b2702003eba7"},
-    {file = "SQLAlchemy-1.4.54-cp38-cp38-win_amd64.whl", hash = "sha256:a01bc25eb7a5688656c8770f931d5cb4a44c7de1b3cec69b84cc9745d1e4cc10"},
-    {file = "SQLAlchemy-1.4.54-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:0b76bbb1cbae618d10679be8966f6d66c94f301cfc15cb49e2f2382563fb6efb"},
-    {file = "SQLAlchemy-1.4.54-cp39-cp39-manylinux1_x86_64.manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_5_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdb2886c0be2c6c54d0651d5a61c29ef347e8eec81fd83afebbf7b59b80b7393"},
-    {file = "SQLAlchemy-1.4.54-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:954816850777ac234a4e32b8c88ac1f7847088a6e90cfb8f0e127a1bf3feddff"},
-    {file = "SQLAlchemy-1.4.54-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1d83cd1cc03c22d922ec94d0d5f7b7c96b1332f5e122e81b1a61fb22da77879a"},
-    {file = "SQLAlchemy-1.4.54-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1576fba3616f79496e2f067262200dbf4aab1bb727cd7e4e006076686413c80c"},
-    {file = "SQLAlchemy-1.4.54-cp39-cp39-win32.whl", hash = "sha256:3112de9e11ff1957148c6de1df2bc5cc1440ee36783412e5eedc6f53638a577d"},
-    {file = "SQLAlchemy-1.4.54-cp39-cp39-win_amd64.whl", hash = "sha256:6da60fb24577f989535b8fc8b2ddc4212204aaf02e53c4c7ac94ac364150ed08"},
-    {file = "sqlalchemy-1.4.54.tar.gz", hash = "sha256:4470fbed088c35dc20b78a39aaf4ae54fe81790c783b3264872a0224f437c31a"},
+    {file = "SQLAlchemy-2.0.39-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:66a40003bc244e4ad86b72abb9965d304726d05a939e8c09ce844d27af9e6d37"},
+    {file = "SQLAlchemy-2.0.39-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67de057fbcb04a066171bd9ee6bcb58738d89378ee3cabff0bffbf343ae1c787"},
+    {file = "SQLAlchemy-2.0.39-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:533e0f66c32093a987a30df3ad6ed21170db9d581d0b38e71396c49718fbb1ca"},
+    {file = "SQLAlchemy-2.0.39-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:7399d45b62d755e9ebba94eb89437f80512c08edde8c63716552a3aade61eb42"},
+    {file = "SQLAlchemy-2.0.39-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:788b6ff6728072b313802be13e88113c33696a9a1f2f6d634a97c20f7ef5ccce"},
+    {file = "SQLAlchemy-2.0.39-cp37-cp37m-win32.whl", hash = "sha256:01da15490c9df352fbc29859d3c7ba9cd1377791faeeb47c100832004c99472c"},
+    {file = "SQLAlchemy-2.0.39-cp37-cp37m-win_amd64.whl", hash = "sha256:f2bcb085faffcacf9319b1b1445a7e1cfdc6fb46c03f2dce7bc2d9a4b3c1cdc5"},
+    {file = "SQLAlchemy-2.0.39-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b761a6847f96fdc2d002e29e9e9ac2439c13b919adfd64e8ef49e75f6355c548"},
+    {file = "SQLAlchemy-2.0.39-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0d7e3866eb52d914aea50c9be74184a0feb86f9af8aaaa4daefe52b69378db0b"},
+    {file = "SQLAlchemy-2.0.39-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:995c2bacdddcb640c2ca558e6760383dcdd68830160af92b5c6e6928ffd259b4"},
+    {file = "SQLAlchemy-2.0.39-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:344cd1ec2b3c6bdd5dfde7ba7e3b879e0f8dd44181f16b895940be9b842fd2b6"},
+    {file = "SQLAlchemy-2.0.39-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:5dfbc543578058c340360f851ddcecd7a1e26b0d9b5b69259b526da9edfa8875"},
+    {file = "SQLAlchemy-2.0.39-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:3395e7ed89c6d264d38bea3bfb22ffe868f906a7985d03546ec7dc30221ea980"},
+    {file = "SQLAlchemy-2.0.39-cp38-cp38-win32.whl", hash = "sha256:bf555f3e25ac3a70c67807b2949bfe15f377a40df84b71ab2c58d8593a1e036e"},
+    {file = "SQLAlchemy-2.0.39-cp38-cp38-win_amd64.whl", hash = "sha256:463ecfb907b256e94bfe7bcb31a6d8c7bc96eca7cbe39803e448a58bb9fcad02"},
+    {file = "sqlalchemy-2.0.39-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6827f8c1b2f13f1420545bd6d5b3f9e0b85fe750388425be53d23c760dcf176b"},
+    {file = "sqlalchemy-2.0.39-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d9f119e7736967c0ea03aff91ac7d04555ee038caf89bb855d93bbd04ae85b41"},
+    {file = "sqlalchemy-2.0.39-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4600c7a659d381146e1160235918826c50c80994e07c5b26946a3e7ec6c99249"},
+    {file = "sqlalchemy-2.0.39-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a06e6c8e31c98ddc770734c63903e39f1947c9e3e5e4bef515c5491b7737dde"},
+    {file = "sqlalchemy-2.0.39-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c4c433f78c2908ae352848f56589c02b982d0e741b7905228fad628999799de4"},
+    {file = "sqlalchemy-2.0.39-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7bd5c5ee1448b6408734eaa29c0d820d061ae18cb17232ce37848376dcfa3e92"},
+    {file = "sqlalchemy-2.0.39-cp310-cp310-win32.whl", hash = "sha256:87a1ce1f5e5dc4b6f4e0aac34e7bb535cb23bd4f5d9c799ed1633b65c2bcad8c"},
+    {file = "sqlalchemy-2.0.39-cp310-cp310-win_amd64.whl", hash = "sha256:871f55e478b5a648c08dd24af44345406d0e636ffe021d64c9b57a4a11518304"},
+    {file = "sqlalchemy-2.0.39-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a28f9c238f1e143ff42ab3ba27990dfb964e5d413c0eb001b88794c5c4a528a9"},
+    {file = "sqlalchemy-2.0.39-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:08cf721bbd4391a0e765fe0fe8816e81d9f43cece54fdb5ac465c56efafecb3d"},
+    {file = "sqlalchemy-2.0.39-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a8517b6d4005facdbd7eb4e8cf54797dbca100a7df459fdaff4c5123265c1cd"},
+    {file = "sqlalchemy-2.0.39-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b2de1523d46e7016afc7e42db239bd41f2163316935de7c84d0e19af7e69538"},
+    {file = "sqlalchemy-2.0.39-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:412c6c126369ddae171c13987b38df5122cb92015cba6f9ee1193b867f3f1530"},
+    {file = "sqlalchemy-2.0.39-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6b35e07f1d57b79b86a7de8ecdcefb78485dab9851b9638c2c793c50203b2ae8"},
+    {file = "sqlalchemy-2.0.39-cp311-cp311-win32.whl", hash = "sha256:3eb14ba1a9d07c88669b7faf8f589be67871d6409305e73e036321d89f1d904e"},
+    {file = "sqlalchemy-2.0.39-cp311-cp311-win_amd64.whl", hash = "sha256:78f1b79132a69fe8bd6b5d91ef433c8eb40688ba782b26f8c9f3d2d9ca23626f"},
+    {file = "sqlalchemy-2.0.39-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c457a38351fb6234781d054260c60e531047e4d07beca1889b558ff73dc2014b"},
+    {file = "sqlalchemy-2.0.39-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:018ee97c558b499b58935c5a152aeabf6d36b3d55d91656abeb6d93d663c0c4c"},
+    {file = "sqlalchemy-2.0.39-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5493a8120d6fc185f60e7254fc056a6742f1db68c0f849cfc9ab46163c21df47"},
+    {file = "sqlalchemy-2.0.39-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b2cf5b5ddb69142511d5559c427ff00ec8c0919a1e6c09486e9c32636ea2b9dd"},
+    {file = "sqlalchemy-2.0.39-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9f03143f8f851dd8de6b0c10784363712058f38209e926723c80654c1b40327a"},
+    {file = "sqlalchemy-2.0.39-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:06205eb98cb3dd52133ca6818bf5542397f1dd1b69f7ea28aa84413897380b06"},
+    {file = "sqlalchemy-2.0.39-cp312-cp312-win32.whl", hash = "sha256:7f5243357e6da9a90c56282f64b50d29cba2ee1f745381174caacc50d501b109"},
+    {file = "sqlalchemy-2.0.39-cp312-cp312-win_amd64.whl", hash = "sha256:2ed107331d188a286611cea9022de0afc437dd2d3c168e368169f27aa0f61338"},
+    {file = "sqlalchemy-2.0.39-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fe193d3ae297c423e0e567e240b4324d6b6c280a048e64c77a3ea6886cc2aa87"},
+    {file = "sqlalchemy-2.0.39-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:79f4f502125a41b1b3b34449e747a6abfd52a709d539ea7769101696bdca6716"},
+    {file = "sqlalchemy-2.0.39-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8a10ca7f8a1ea0fd5630f02feb055b0f5cdfcd07bb3715fc1b6f8cb72bf114e4"},
+    {file = "sqlalchemy-2.0.39-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e6b0a1c7ed54a5361aaebb910c1fa864bae34273662bb4ff788a527eafd6e14d"},
+    {file = "sqlalchemy-2.0.39-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52607d0ebea43cf214e2ee84a6a76bc774176f97c5a774ce33277514875a718e"},
+    {file = "sqlalchemy-2.0.39-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c08a972cbac2a14810463aec3a47ff218bb00c1a607e6689b531a7c589c50723"},
+    {file = "sqlalchemy-2.0.39-cp313-cp313-win32.whl", hash = "sha256:23c5aa33c01bd898f879db158537d7e7568b503b15aad60ea0c8da8109adf3e7"},
+    {file = "sqlalchemy-2.0.39-cp313-cp313-win_amd64.whl", hash = "sha256:4dabd775fd66cf17f31f8625fc0e4cfc5765f7982f94dc09b9e5868182cb71c0"},
+    {file = "sqlalchemy-2.0.39-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2600a50d590c22d99c424c394236899ba72f849a02b10e65b4c70149606408b5"},
+    {file = "sqlalchemy-2.0.39-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4eff9c270afd23e2746e921e80182872058a7a592017b2713f33f96cc5f82e32"},
+    {file = "sqlalchemy-2.0.39-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7332868ce891eda48896131991f7f2be572d65b41a4050957242f8e935d5d7"},
+    {file = "sqlalchemy-2.0.39-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:125a7763b263218a80759ad9ae2f3610aaf2c2fbbd78fff088d584edf81f3782"},
+    {file = "sqlalchemy-2.0.39-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:04545042969833cb92e13b0a3019549d284fd2423f318b6ba10e7aa687690a3c"},
+    {file = "sqlalchemy-2.0.39-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:805cb481474e111ee3687c9047c5f3286e62496f09c0e82e8853338aaaa348f8"},
+    {file = "sqlalchemy-2.0.39-cp39-cp39-win32.whl", hash = "sha256:34d5c49f18778a3665d707e6286545a30339ad545950773d43977e504815fa70"},
+    {file = "sqlalchemy-2.0.39-cp39-cp39-win_amd64.whl", hash = "sha256:35e72518615aa5384ef4fae828e3af1b43102458b74a8c481f69af8abf7e802a"},
+    {file = "sqlalchemy-2.0.39-py3-none-any.whl", hash = "sha256:a1c6b0a5e3e326a466d809b651c63f278b1256146a377a528b6938a279da334f"},
+    {file = "sqlalchemy-2.0.39.tar.gz", hash = "sha256:5d2d1fe548def3267b4c70a8568f108d1fed7cbbeccb9cc166e05af2abc25c22"},
 ]
 
 [package.dependencies]
-greenlet = {version = "!=0.4.17", markers = "python_version >= \"3\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"}
-mypy = {version = ">=0.910", optional = true, markers = "python_version >= \"3\" and extra == \"mypy\""}
-sqlalchemy2-stubs = {version = "*", optional = true, markers = "extra == \"mypy\""}
+greenlet = {version = "!=0.4.17", markers = "python_version < \"3.14\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"}
+typing-extensions = ">=4.6.0"
 
 [package.extras]
-aiomysql = ["aiomysql (>=0.2.0) ; python_version >= \"3\"", "greenlet (!=0.4.17) ; python_version >= \"3\""]
-aiosqlite = ["aiosqlite ; python_version >= \"3\"", "greenlet (!=0.4.17) ; python_version >= \"3\"", "typing_extensions (!=3.10.0.1)"]
-asyncio = ["greenlet (!=0.4.17) ; python_version >= \"3\""]
-asyncmy = ["asyncmy (>=0.2.3,!=0.2.4) ; python_version >= \"3\"", "greenlet (!=0.4.17) ; python_version >= \"3\""]
-mariadb-connector = ["mariadb (>=1.0.1,!=1.1.2) ; python_version >= \"3\"", "mariadb (>=1.0.1,!=1.1.2) ; python_version >= \"3\""]
+aiomysql = ["aiomysql (>=0.2.0)", "greenlet (!=0.4.17)"]
+aioodbc = ["aioodbc", "greenlet (!=0.4.17)"]
+aiosqlite = ["aiosqlite", "greenlet (!=0.4.17)", "typing_extensions (!=3.10.0.1)"]
+asyncio = ["greenlet (!=0.4.17)"]
+asyncmy = ["asyncmy (>=0.2.3,!=0.2.4,!=0.2.6)", "greenlet (!=0.4.17)"]
+mariadb-connector = ["mariadb (>=1.0.1,!=1.1.2,!=1.1.5,!=1.1.10)"]
 mssql = ["pyodbc"]
-mssql-pymssql = ["pymssql", "pymssql"]
-mssql-pyodbc = ["pyodbc", "pyodbc"]
-mypy = ["mypy (>=0.910) ; python_version >= \"3\"", "sqlalchemy2-stubs"]
-mysql = ["mysqlclient (>=1.4.0) ; python_version >= \"3\"", "mysqlclient (>=1.4.0,<2) ; python_version < \"3\""]
-mysql-connector = ["mysql-connector-python", "mysql-connector-python"]
-oracle = ["cx_oracle (>=7) ; python_version >= \"3\"", "cx_oracle (>=7,<8) ; python_version < \"3\""]
+mssql-pymssql = ["pymssql"]
+mssql-pyodbc = ["pyodbc"]
+mypy = ["mypy (>=0.910)"]
+mysql = ["mysqlclient (>=1.4.0)"]
+mysql-connector = ["mysql-connector-python"]
+oracle = ["cx_oracle (>=8)"]
+oracle-oracledb = ["oracledb (>=1.0.1)"]
 postgresql = ["psycopg2 (>=2.7)"]
-postgresql-asyncpg = ["asyncpg ; python_version >= \"3\"", "asyncpg ; python_version >= \"3\"", "greenlet (!=0.4.17) ; python_version >= \"3\"", "greenlet (!=0.4.17) ; python_version >= \"3\""]
-postgresql-pg8000 = ["pg8000 (>=1.16.6,!=1.29.0) ; python_version >= \"3\"", "pg8000 (>=1.16.6,!=1.29.0) ; python_version >= \"3\""]
+postgresql-asyncpg = ["asyncpg", "greenlet (!=0.4.17)"]
+postgresql-pg8000 = ["pg8000 (>=1.29.1)"]
+postgresql-psycopg = ["psycopg (>=3.0.7)"]
 postgresql-psycopg2binary = ["psycopg2-binary"]
 postgresql-psycopg2cffi = ["psycopg2cffi"]
-pymysql = ["pymysql (<1) ; python_version < \"3\"", "pymysql ; python_version >= \"3\""]
-sqlcipher = ["sqlcipher3_binary ; python_version >= \"3\""]
-
-[[package]]
-name = "sqlalchemy2-stubs"
-version = "0.0.2a25"
-description = "Typing Stubs for SQLAlchemy 1.4"
-optional = false
-python-versions = ">=3.6"
-groups = ["dev"]
-files = [
-    {file = "sqlalchemy2-stubs-0.0.2a25.tar.gz", hash = "sha256:2fbfddfee7fc6b45206dc52e9fe9d91a787efb6af13191debe84dda9b4798abd"},
-    {file = "sqlalchemy2_stubs-0.0.2a25-py3-none-any.whl", hash = "sha256:9104894cee3159906079c4a31c2a66fbedfc72a381c51dfd1d8ebae8ffd7f2ca"},
-]
-
-[package.dependencies]
-typing-extensions = ">=3.7.4"
+postgresql-psycopgbinary = ["psycopg[binary] (>=3.0.7)"]
+pymysql = ["pymysql"]
+sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
 name = "sqlglot"
@@ -1653,7 +1654,7 @@ version = "4.6.3"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 optional = false
 python-versions = ">=3.7"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "typing_extensions-4.6.3-py3-none-any.whl", hash = "sha256:88a4153d8505aabbb4e13aacb7c486c2b4a33ca3b3f807914a9b4c844c471c26"},
     {file = "typing_extensions-4.6.3.tar.gz", hash = "sha256:d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5"},
@@ -1773,4 +1774,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8,<4"
-content-hash = "6f046554bc7605f1a73bc65bc913bdf0f775c41bc754f0cd3b78391784dd999d"
+content-hash = "816b82ee4360ceaec599227a859829c835b7dd0932510dc961876cbc6c3fdfad"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ mypy = "^1.4"
 hypothesis = "^6.75.2"
 pandas = "^1"
 jupysql = "^0.10.0"
-sqlalchemy = {version="^1.3.19", extras=['mypy']}
+sqlalchemy = ">=2"
 pytest-cov = {extras = ["coverage"], version = "^5.0.0"}
 snapshottest = "^0.6.0"
 pytest-remotedata = "^0.4.0"
@@ -51,7 +51,6 @@ check_untyped_defs = true
 disallow_untyped_decorators = true
 warn_redundant_casts = true
 warn_unused_ignores = true
-plugins = ['sqlalchemy.ext.mypy.plugin']
 
 [tool.ruff]
 target-version = "py38"


### PR DESCRIPTION
This shouldn't affec this lib's compatibility with sqlalchemy 1.X for actual users, except maybe for typing. This change removes about 20 warnings that happen during pytest.