### PR TITLE
Add the ability to run actions right after connecting to the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Basic SQLAlchemy driver for [DuckDB](https://duckdb.org/)
   - [Alembic Integration](#alembic-integration)
   - [Preloading extensions (experimental)](#preloading-extensions-experimental)
   - [Registering Filesystems](#registering-filesystems)
+  - [Running actions right after connecting](#running-actions-right-after-connecting)
   - [The name](#the-name)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
@@ -176,7 +177,8 @@ create_engine(
         'preload_extensions': ['https'],
         'config': {
             's3_region': 'ap-southeast-1'
-        }
+        },
+        'pre_actions': ["ATTACH 'file.db' AS file_db';"]
     }
 )
 ```
@@ -199,6 +201,24 @@ create_engine(
 )
 ```
 
+## Running actions right after connecting
+You can run arbitrary SQL commands right after connecting by passing a list of SQL commands to the `pre_actions` parameter in `connect_args`
+
+```python
+from sqlalchemy import create_engine
+create_engine(
+    'duckdb:///:memory:',
+    connect_args={
+        'pre_actions': [
+            "ATTACH 'file.db' AS file_db';",
+            "SET some_config_option='some_value';"
+        ]
+    }
+)
+```
+
 ## The name
 
 Yes, I'm aware this package should be named `duckdb-driver` or something, I wasn't thinking when I named it and it's too hard to change the name now
+
+

--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -285,6 +285,7 @@ class Dialect(PGDialect_psycopg2):
     def connect(self, *cargs: Any, **cparams: Any) -> "Connection":
         core_keys = get_core_config()
         preload_extensions = cparams.pop("preload_extensions", [])
+        pre_actions = cparams.pop("pre_actions", [])
         config = dict(cparams.get("config", {}))
         cparams["config"] = config
         config.update(cparams.pop("url_config", {}))
@@ -305,6 +306,9 @@ class Dialect(PGDialect_psycopg2):
 
         for filesystem in filesystems:
             conn.register_filesystem(filesystem)
+
+        for action in pre_actions:
+            conn.execute(action)
 
         apply_config(self, conn, ext)
 

--- a/duckdb_engine/tests/test_basic.py
+++ b/duckdb_engine/tests/test_basic.py
@@ -278,6 +278,7 @@ def test_preload_extension() -> None:
             text("SELECT * FROM read_parquet('https://domain/path/to/file.parquet');")
         )
 
+
 def test_pre_actions() -> None:
     engine = create_engine(
         "duckdb:///",
@@ -289,9 +290,7 @@ def test_pre_actions() -> None:
 
     # check that we get an error indicating that the extension was loaded
     with engine.connect() as conn:
-        conn.execute(
-            text("SELECT ST_Affine(ST_Point(1, 1),1, 0, 0, 1, 2, 3);")
-        )
+        conn.execute(text("SELECT ST_Affine(ST_Point(1, 1),1, 0, 0, 1, 2, 3);"))
 
 
 @fixture

--- a/duckdb_engine/tests/test_basic.py
+++ b/duckdb_engine/tests/test_basic.py
@@ -288,7 +288,7 @@ def test_pre_actions() -> None:
         },
     )
 
-    # check that we get an error indicating that the extension was loaded
+    # check that we can use spatial functions
     with engine.connect() as conn:
         conn.execute(text("SELECT ST_Affine(ST_Point(1, 1),1, 0, 0, 1, 2, 3);"))
 

--- a/duckdb_engine/tests/test_basic.py
+++ b/duckdb_engine/tests/test_basic.py
@@ -278,6 +278,21 @@ def test_preload_extension() -> None:
             text("SELECT * FROM read_parquet('https://domain/path/to/file.parquet');")
         )
 
+def test_pre_actions() -> None:
+    engine = create_engine(
+        "duckdb:///",
+        connect_args={
+            "pre_actions": ["INSTALL SPATIAL", "LOAD SPATIAL"],
+            "config": {"s3_region": "ap-southeast-2", "s3_use_ssl": True},
+        },
+    )
+
+    # check that we get an error indicating that the extension was loaded
+    with engine.connect() as conn:
+        conn.execute(
+            text("SELECT ST_Affine(ST_Point(1, 1),1, 0, 0, 1, 2, 3);")
+        )
+
 
 @fixture
 def inspector(engine: Engine, session: Session) -> Inspector:


### PR DESCRIPTION
You can run arbitrary SQL commands right after connecting by passing a list of SQL commands to the `pre_actions` parameter in `connect_args`

```python
from sqlalchemy import create_engine
create_engine(
    'duckdb:///:memory:',
    connect_args={
        'pre_actions': [
            "ATTACH 'file.db' AS file_db';",
            "SET some_config_option='some_value';"
        ]
    }
)
```