### PR TITLE
Add type: DOUBLE (float8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ coverage.xml
 .vscode
 results.xml
 venv
+.venv

--- a/duckdb_engine/datatypes.py
+++ b/duckdb_engine/datatypes.py
@@ -222,8 +222,8 @@ ISCHEMA_NAMES = {
 if IS_GT_1:
     ISCHEMA_NAMES["varint"] = VarInt
 if IS_SQLA_GT_2:
-    ISCHEMA_NAMES["float8"] = sqltypes.DOUBLE # type: ignore[attr-defined] 
-    ISCHEMA_NAMES["double"] = sqltypes.DOUBLE # type: ignore[attr-defined] 
+    ISCHEMA_NAMES["float8"] = sqltypes.DOUBLE  # type: ignore[attr-defined]
+    ISCHEMA_NAMES["double"] = sqltypes.DOUBLE  # type: ignore[attr-defined]
 
 
 def register_extension_types() -> None:

--- a/duckdb_engine/datatypes.py
+++ b/duckdb_engine/datatypes.py
@@ -13,6 +13,7 @@ from typing import Any, Callable, Dict, Optional, Type
 import duckdb
 from packaging.version import Version
 from sqlalchemy import exc
+import sqlalchemy
 from sqlalchemy.dialects.postgresql.base import PGIdentifierPreparer, PGTypeCompiler
 from sqlalchemy.engine import Dialect
 from sqlalchemy.ext.compiler import compiles
@@ -26,8 +27,10 @@ from sqlalchemy.types import BigInteger, Integer, SmallInteger, String
 (BigInteger, SmallInteger)  # pure reexport
 
 duckdb_version = duckdb.__version__
+sqlalchemy_version = sqlalchemy.__version__
 
 IS_GT_1 = Version(duckdb_version) > Version("1.0.0")
+IS_SQLA_GT_2 = Version(sqlalchemy_version) > Version("2.0.0")
 
 
 class UInt64(Integer):
@@ -206,7 +209,6 @@ ISCHEMA_NAMES = {
     "timetz": sqltypes.TIME,
     "timestamptz": sqltypes.TIMESTAMP,
     "float4": sqltypes.FLOAT,
-    "float8": sqltypes.FLOAT,
     "usmallint": USmallInteger,
     "uinteger": UInteger,
     "ubigint": UBigInteger,
@@ -219,6 +221,9 @@ ISCHEMA_NAMES = {
 }
 if IS_GT_1:
     ISCHEMA_NAMES["varint"] = VarInt
+if IS_SQLA_GT_2:
+    ISCHEMA_NAMES["float8"] = sqltypes.DOUBLE
+    ISCHEMA_NAMES["double"] = sqltypes.DOUBLE
 
 
 def register_extension_types() -> None:

--- a/duckdb_engine/datatypes.py
+++ b/duckdb_engine/datatypes.py
@@ -11,9 +11,9 @@ import typing
 from typing import Any, Callable, Dict, Optional, Type
 
 import duckdb
+import sqlalchemy
 from packaging.version import Version
 from sqlalchemy import exc
-import sqlalchemy
 from sqlalchemy.dialects.postgresql.base import PGIdentifierPreparer, PGTypeCompiler
 from sqlalchemy.engine import Dialect
 from sqlalchemy.ext.compiler import compiles

--- a/duckdb_engine/datatypes.py
+++ b/duckdb_engine/datatypes.py
@@ -222,8 +222,8 @@ ISCHEMA_NAMES = {
 if IS_GT_1:
     ISCHEMA_NAMES["varint"] = VarInt
 if IS_SQLA_GT_2:
-    ISCHEMA_NAMES["float8"] = sqltypes.DOUBLE
-    ISCHEMA_NAMES["double"] = sqltypes.DOUBLE
+    ISCHEMA_NAMES["float8"] = sqltypes.DOUBLE # type: ignore[attr-defined] 
+    ISCHEMA_NAMES["double"] = sqltypes.DOUBLE # type: ignore[attr-defined] 
 
 
 def register_extension_types() -> None:

--- a/duckdb_engine/tests/test_datatypes.py
+++ b/duckdb_engine/tests/test_datatypes.py
@@ -166,6 +166,25 @@ def test_double_in_sqla_v2(engine: Engine) -> None:
     with engine.begin() as con:
         con.execute(t.select())
 
+def test_double(engine: Engine, session: Session) -> None:
+    sqlalchemy = importorskip("sqlalchemy", "2.0.0")
+    base = declarative_base()
+
+    class Entry(base):
+        __tablename__ = "test_double"
+
+        id = Column(Integer, primary_key=True, default=0)
+        value = Column(sqlalchemy.DOUBLE, nullable=False)
+
+    base.metadata.create_all(bind=engine)
+
+    session.add(Entry(value=42.000001))  # type: ignore[call-arg]
+    session.commit()
+
+    result = session.query(Entry).one()
+
+    assert result.value == 42.000001
+
 
 def test_all_types_reflection(engine: Engine) -> None:
     importorskip("sqlalchemy", "1.4.0")

--- a/duckdb_engine/tests/test_datatypes.py
+++ b/duckdb_engine/tests/test_datatypes.py
@@ -166,6 +166,7 @@ def test_double_in_sqla_v2(engine: Engine) -> None:
     with engine.begin() as con:
         con.execute(t.select())
 
+
 def test_double(engine: Engine, session: Session) -> None:
     sqlalchemy = importorskip("sqlalchemy", "2.0.0")
     base = declarative_base()


### PR DESCRIPTION
Since SQLAlchemy 2.0.0 we can use the DOUBLE (float8) type to handle duckdb double (float8) columns.

This PR makes it work in duckdb_engine.

Tested with sqlalchemy 2.0.0

closes #1384 