### PR TITLE
Fix SQLAlchemy Sequence documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ conn.execute("select * from dataframe_name")
 Duckdb's SQL parser is based on the PostgreSQL parser, but not all features in PostgreSQL are supported in duckdb. Because the `duckdb_engine` dialect is derived from the `postgresql` dialect, `SQLAlchemy` may try to use PostgreSQL-only features. Below are some caveats to look out for.
 
 ### Auto-incrementing ID columns
-When defining an Integer column as a primary key, `SQLAlchemy` uses the `SERIAL` datatype for PostgreSQL. Duckdb does not yet support this datatype because it's a non-standard PostgreSQL legacy type, so a workaround is to use the `SQLAlchemy.Sequence()` object to auto-increment the key. For more information on sequences, you can find the [`SQLAlchemy Sequence` documentation here](https://docs.sqlalchemy.org/en/14/core/defaults.html#associating-a-sequence-as-the-server-side-default).
+When defining an Integer column as a primary key, `SQLAlchemy` uses the `SERIAL` datatype for PostgreSQL. Duckdb does not yet support this datatype because it's a non-standard PostgreSQL legacy type, so a workaround is to use the `SQLAlchemy.Sequence()` object to auto-increment the key. For more information on sequences, you can find the [`SQLAlchemy Sequence` documentation here](https://docs.sqlalchemy.org/en/20/core/defaults.html#associating-a-sequence-as-the-server-side-default).
 
 The following example demonstrates how to create an auto-incrementing ID column for a simple table:
 


### PR DESCRIPTION
Updated the link to the SQLAlchemy Sequence documentation to point to version 2.0 (latest stable version)