### PR TITLE
Fix: Motherduck config and add session_name

### DIFF
--- a/duckdb_engine/config.py
+++ b/duckdb_engine/config.py
@@ -11,14 +11,17 @@ TYPES: Dict[Type, TypeEngine] = {int: Integer(), str: String(), bool: Boolean()}
 
 @lru_cache()
 def get_core_config() -> Set[str]:
-    # List of connection string parameters that are supported by MotherDuck
-    # See: https://motherduck.com/docs/key-tasks/authenticating-and-connecting-to-motherduck/authenticating-to-motherduck/
+    # MotherDuck settings that must be passed to duckdb.connect() as config:
+    # applying them via SET after the connection is established either fails
+    # with "can only be set during initialization" or happens too late. As
+    # duckdb settings they carry the motherduck_ prefix; the bare
+    # attach_mode/saas_mode spellings are only valid inside the md: path
+    # itself (e.g. "md:db?attach_mode=single") and were never recognized by
+    # duckdb.connect().
     motherduck_config_keys = {
         "motherduck_token",
-        "attach_mode",
-        "saas_mode",
-        # Must be passed at connect time: a SET after the connection is
-        # established fails with "can only be set during initialization".
+        "motherduck_attach_mode",
+        "motherduck_saas_mode",
         "motherduck_session_name",
         "motherduck_session_hint",  # deprecated alias of motherduck_session_name
     }

--- a/duckdb_engine/config.py
+++ b/duckdb_engine/config.py
@@ -13,7 +13,15 @@ TYPES: Dict[Type, TypeEngine] = {int: Integer(), str: String(), bool: Boolean()}
 def get_core_config() -> Set[str]:
     # List of connection string parameters that are supported by MotherDuck
     # See: https://motherduck.com/docs/key-tasks/authenticating-and-connecting-to-motherduck/authenticating-to-motherduck/
-    motherduck_config_keys = {"motherduck_token", "attach_mode", "saas_mode"}
+    motherduck_config_keys = {
+        "motherduck_token",
+        "attach_mode",
+        "saas_mode",
+        # Must be passed at connect time: a SET after the connection is
+        # established fails with "can only be set during initialization".
+        "motherduck_session_name",
+        "motherduck_session_hint",  # deprecated alias of motherduck_session_name
+    }
 
     rows = (
         duckdb.connect(":memory:")

--- a/duckdb_engine/tests/test_basic.py
+++ b/duckdb_engine/tests/test_basic.py
@@ -40,6 +40,7 @@ from sqlalchemy.orm import Session, relationship, sessionmaker
 
 from .. import Dialect, insert, supports_attach, supports_user_agent
 from .._supports import has_comment_support
+from ..config import get_core_config
 
 try:
     # sqlalchemy 2
@@ -706,3 +707,11 @@ def test_register_filesystem() -> None:
     with engine.connect() as conn:
         duckdb_conn = getattr(conn.connection.dbapi_connection, "_ConnectionWrapper__c")
         assert duckdb.list_filesystems(connection=duckdb_conn) == ["memory", "file"]
+
+
+def test_motherduck_keys_are_connect_time_config() -> None:
+    assert {
+        "motherduck_token",
+        "motherduck_session_name",
+        "motherduck_session_hint",
+    } <= get_core_config()

--- a/duckdb_engine/tests/test_basic.py
+++ b/duckdb_engine/tests/test_basic.py
@@ -710,8 +710,14 @@ def test_register_filesystem() -> None:
 
 
 def test_motherduck_keys_are_connect_time_config() -> None:
+    core = get_core_config()
     assert {
         "motherduck_token",
+        "motherduck_attach_mode",
+        "motherduck_saas_mode",
         "motherduck_session_name",
         "motherduck_session_hint",
-    } <= get_core_config()
+    } <= core
+    # The bare spellings are md: path parameters, not duckdb settings.
+    assert "attach_mode" not in core
+    assert "saas_mode" not in core


### PR DESCRIPTION
### The issue
The `session_name` (previously `session_hint`) can only be set during connection initialisation. A SET after connecting fails with a "can only be set during initialization". This adds the `"motherduck_session_name"` and (deprecated) `"motherduck_session_hint"` to the core config of MotherDuck.

I also noticed that the other config keys were missing the required `motherduck_` namespacing as well, so I updated those config keys. This didn't work before:
```shell
uvx --with duckdb-engine --with 'duckdb==1.5.4' python -c "from sqlalchemy import create_engine; create_engine('duckdb:///md:?attach_mode=single').connect()"
```

Gives:
```
[...]
sqlalchemy.exc.ProgrammingError: (_duckdb.InvalidInputException) Invalid Input Error: The following options were not recognized: attach_mode
(Background on this error at: https://sqlalche.me/e/20/f405)
```

And
```shell
uvx --with duckdb-engine --with 'duckdb==1.5.4' python -c "from sqlalchemy import create_engine; create_engine('duckdb:///md:?motherduck_attach_mode=single').connect()"
```

Gives:
```
[...]
sqlalchemy.exc.DBAPIError: (_duckdb.Error) setting 'motherduck_attach_mode' can only be set during initialization
(Background on this error at: https://sqlalche.me/e/20/dbapi)
```

After this change, this should work: `duckdb:///md:?motherduck_session_name=alice&motherduck_attach_mode=single`.