### PR TITLE
fix: preserve backslashes in string literals

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
     rev: v1.18.2
     hooks:
      - id: mypy
+       language_version: python3.11
        additional_dependencies:
           - "duckdb==0.10.1"
           - "pytest==6.2.4"

--- a/duckdb_engine/__init__.py
+++ b/duckdb_engine/__init__.py
@@ -247,6 +247,8 @@ class Dialect(PGDialect_psycopg2):
     name = "duckdb"
     driver = "duckdb_engine"
     _has_events = False
+    # DuckDB only interprets backslash escapes in E-prefixed string literals.
+    _backslash_escapes = False
     supports_statement_cache = False
     supports_comments = has_comment_support()
     supports_sane_rowcount = False

--- a/duckdb_engine/tests/test_basic.py
+++ b/duckdb_engine/tests/test_basic.py
@@ -27,6 +27,7 @@ from sqlalchemy import (
     create_engine,
     func,
     inspect,
+    literal,
     select,
     text,
     types,
@@ -124,6 +125,37 @@ def test_basic(session: Session) -> None:
     frank = session.query(FakeModel).one()  # act
 
     assert frank.name == "Frank"
+
+
+@mark.parametrize("initialized", [False, True])
+@mark.parametrize(
+    "value",
+    [
+        "plain text",
+        "",
+        r"name\email",
+        r"\\server\share",
+        r"literal\nsequence",
+        "actual\nnewline",
+        "trailing\\",
+        r"C:\O'Reilly\notes",
+        "café\\'東京",
+    ],
+)
+def test_literal_binds_preserve_string_values(
+    session: Session, engine: Engine, value: str, initialized: bool
+) -> None:
+    session.add(FakeModel(name=value))
+    session.commit()
+
+    query = session.query(literal(value)).filter(FakeModel.name.in_([value]))
+    assert query.all() == [(value,)]
+
+    dialect = engine.dialect if initialized else Dialect()
+    compiled = query.statement.compile(
+        dialect=dialect, compile_kwargs={"literal_binds": True}
+    )
+    assert session.connection().execute(compiled).fetchall() == [(value,)]
 
 
 def test_foreign(session: Session) -> None:


### PR DESCRIPTION
Values containing backslashes change when compiled with `literal_binds=True`: `name\email` becomes `name\\email`, so filters can miss rows or match the wrong row. This reproduces apache/superset#38453.

Set `_backslash_escapes = False` because DuckDB only interprets these escapes in E-prefixed strings. This reuses SQLAlchemy's existing string quoting. Parameterized tests cover fresh and initialized dialects, quotes, Unicode, newlines, and trailing/repeated backslashes.

Pin mypy's hook to Python 3.11 so its existing DuckDB 0.10.1 dependency installs in pre-commit.ci; the default Python 3.14 environment fails before running checks.

Validation:
- All 18 new cases pass on SQLAlchemy 1.3, 1.4, and 2.0.
- Full SQLAlchemy 1.4 suite: 109 passed, 10 skipped. The 1.3 basic and 2.0 full runs have the same five failures on unchanged upstream code.
- All-file pre-commit checks and wheel build pass; pre-commit.ci now passes too.
- A running Superset dashboard, native-filter interaction, and eight chart API cases return the correct rows after installing the wheel.
